### PR TITLE
Translate items in Dropdown list within metadata form

### DIFF
--- a/classes/local/addvideo_form.php
+++ b/classes/local/addvideo_form.php
@@ -53,6 +53,7 @@ class addvideo_form extends \moodleform {
                     }
                 }
                 if ($field->param_json) {
+                    $field->param_json = format_string($field->param_json, true, array('filter' => 'true'));
                     $param = $field->datatype == 'static' ? $field->param_json : (array)json_decode($field->param_json);
                 }
                 if ($field->datatype == 'autocomplete') {

--- a/classes/local/updatemetadata_form.php
+++ b/classes/local/updatemetadata_form.php
@@ -42,6 +42,7 @@ class updatemetadata_form extends \moodleform {
             $param = array();
             $attributes = array();
             if ($field->param_json) {
+                $field->param_json = format_string($field->param_json, true, array('filter' => 'true'));
                 $param = $field->datatype == 'static' ? $field->param_json : (array)json_decode($field->param_json);
             }
             if ($field->datatype == 'autocomplete') {

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -299,7 +299,12 @@ $string['catalogparam_help'] = '<b>JSON format:</b> {"param1":"value1", "param2"
                                 <b>Date Time Selector (datetime):</b> Parameters will be defined as <a target="_blank" href="https://docs.moodle.org/dev/lib/formslib.php_Form_Definition#date_selector">date_selector variables</a> . i.e. {"startyear": "1990", "stopyear": "2020"} which defines date range to be selected between 1990 - 2020';
 $string['addcatalog'] = 'Add new metadata';
 $string['descriptionmdfn'] = 'This is the actual field name passing as metadata (id); the presented name according to this field name should be set in language string.';
-$string['descriptionmdpj'] = 'The value should be JSON string format and it is used to define parameters for the field!';
+$string['descriptionmdpj'] = 'The value should be JSON string format and it is used to define parameters for the field!<br>You may enter <a href="https://docs.moodle.org/en/Multi-language_content_filter">multi-language</a> strings in this format:
+
+    <pre>
+    &ltspan lang="en" class="multilang"&gt{"en": "English", "de": "German"}&lt/span&gt
+    &ltspan lang="de" class="multilang"&gt{"en": "Englisch", "de": "Deutsch"}&lt/span&gt
+    </pre>';
 $string['empty_catalogname'] = 'This field must not be empty';
 $string['space_catalogname'] = 'This field must not contain space';
 $string['exists_catalogname'] = 'The field is already existed';


### PR DESCRIPTION
This is the solution referred [here](https://github.com/unirz-tu-ilmenau/moodle-block_opencast/issues/135#issuecomment-620488264)

The dropdown list (e.g language field under Metadata in Add Video form) items are defined in install.php and hence do not get updated through the normal process of translation through lang file. My solution offers a way to remedy this. 

1. **String definitions**: Need to define string for the dropdown items in language files. I added the language_params and license_params in the english language file, so that developers can access and provide translations through AMOS. I provide the 'de' lang file as well in case people want to go by the old language folder approach.

2. **Calling the string definitions:** Next we call the translation defined in the previous step. The code doesn this by:

- Check if a field has value for param_json attribute
- if yes, it checks language files for corresponding parameters by searching in the format <_fieldname_>_params 
- if there is definition for the keyword in language file, code uses that, else it just takes the original value of the param_json attribute
