### PR TITLE
importvideos_wizardstep1sourcecoursenone error was shown even if the user has more than one course

### DIFF
--- a/importvideos.php
+++ b/importvideos.php
@@ -92,7 +92,7 @@ switch ($step) {
 
         // If there isn't any other course which can be used as import source.
         $possiblesourcecourses = get_user_capability_course(
-                'block/opencast:manualimportsource', null, true, '', '', 1);
+                'block/opencast:manualimportsource');
         $possiblesourcecoursescount = count($possiblesourcecourses);
         if ($possiblesourcecoursescount < 1 || ($possiblesourcecoursescount == 1 && $possiblesourcecourses[0]->id == $courseid)) {
             // Use step 1 form.


### PR DESCRIPTION
In step 1 of the Opencast import wizard, the wizard checks if the user has at least one course which he could import videos from.
This is done by getting the courses where the user has the 'block/opencast:manualimportsource' capability. To reduce the amount of gathered data, the list of courses is limited to 1 course already during the database request and afterwards this single returned course ID is compared with the current course ID.

Due to this limitation to 1 course, the rare edge case can happen that the current course is returned as first (and only) course and then the wizard does not regognize that there are more courses to import videos from. As a result, the user sees the 'There isn't any other course than this course which you are allowed to import videos from.' error message by mistake.

This patch fixes this edge case by simply getting the whole list of courses in any case.

'There isn't any other course than this course which you are allowed to import videos from.'