### PR TITLE
Drop block_opencast_series DB table - Solves #138.

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -51,17 +51,6 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
     </TABLE>
-    <TABLE NAME="block_opencast_series" COMMENT="Stores the series identifier for a course.">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="series" TYPE="char" LENGTH="36" NOTNULL="true" SEQUENCE="false" COMMENT="identifier of the series"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="fk_course" TYPE="foreign-unique" FIELDS="courseid" REFTABLE="course" REFFIELDS="id"/>
-      </KEYS>
-    </TABLE>
     <TABLE NAME="block_opencast_draftitemid" COMMENT="Track the user draft itemids, that were used by opencast upload form.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -550,5 +550,19 @@ function xmldb_block_opencast_upgrade($oldversion) {
         upgrade_block_savepoint(true, 2021061600, 'opencast');
     }
 
+    if ($oldversion < 2021062401) {
+
+        // Define table block_opencast_series to be dropped.
+        $table = new xmldb_table('block_opencast_series');
+
+        if ($dbman->table_exists($table)) {
+            // Drop table.
+            $dbman->drop_table($table);
+        }
+
+        // Opencast savepoint reached.
+        upgrade_block_savepoint(true, 2021062401, 'opencast');
+    }
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021062300;
+$plugin->version = 2021062401;
 $plugin->requires = 2017111300;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'v3.11-r1';


### PR DESCRIPTION
This patch simply drops the block_opencast_series DB table as Course -> Series mappings are stored in tool_opencast_series and as there aren't any code snippets which access the block_opencast_series table.