### PR TITLE
Change the button label from 'Save changes' to 'Add video' - Solves #195.

### DIFF
--- a/classes/local/addvideo_form.php
+++ b/classes/local/addvideo_form.php
@@ -195,7 +195,7 @@ class addvideo_form extends \moodleform
 
         $mform->closeHeaderBefore('buttonar');
 
-        $this->add_action_buttons(true, get_string('savechanges'));
+        $this->add_action_buttons(true, get_string('addvideo', 'block_opencast'));
     }
 
     /**

--- a/tests/behat/block_opencast.feature
+++ b/tests/behat/block_opencast.feature
@@ -45,7 +45,7 @@ Feature: Add Opencast block as Teacher
     And I click on "Add video" "button"
     And I set the field "Title" to "Test"
     And I upload "blocks/opencast/tests/fixtures/test.mp4" file to "Presenter video" filemanager
-    And I click on "Save changes" "button"
+    And I click on "Add video" "button"
     Then I should see "Test"
     And I should see "test.mp4"
     And I should see "Ready for transfer"
@@ -56,7 +56,7 @@ Feature: Add Opencast block as Teacher
     And I click on "Add video" "button"
     And I set the field "Title" to "Test"
     And I upload "blocks/opencast/tests/fixtures/test.mp4" file to "Presenter video" filemanager
-    And I click on "Save changes" "button"
+    And I click on "Add video" "button"
     And I run the scheduled task "\block_opencast\task\process_upload_cron"
     And I wait "10" seconds
     And I run the scheduled task "\block_opencast\task\process_upload_cron"
@@ -71,7 +71,7 @@ Feature: Add Opencast block as Teacher
     And I click on "Add video" "button"
     And I set the field "Title" to "Test"
     And I upload "blocks/opencast/tests/fixtures/test.mp4" file to "Presenter video" filemanager
-    And I click on "Save changes" "button"
+    And I click on "Add video" "button"
     And I run the scheduled task "\block_opencast\task\process_upload_cron"
     And I wait "10" seconds
     And I run the scheduled task "\block_opencast\task\process_upload_cron"


### PR DESCRIPTION
On addvideo.php, the button to submit the form said 'Save changes'.
This patch changes the label to 'Add video' because this is what the button is doing.