### PR TITLE
When creating Opencast modules, respect the $CFG->completiondefault setting for completion tracking - Fixes #189.

### DIFF
--- a/classes/local/activitymodulemanager.php
+++ b/classes/local/activitymodulemanager.php
@@ -180,6 +180,8 @@ class activitymodulemanager
      */
     public static function build_activity_modinfo($pluginid, $title, $sectionid, $opencastid, $type,
                                                   $introtext = '', $introformat = FORMAT_HTML, $availability = null) {
+        global $CFG;
+
         // Create standard class object.
         $moduleinfo = new \stdClass();
 
@@ -201,7 +203,7 @@ class activitymodulemanager
         $moduleinfo->groupmode = NOGROUPS;
         $moduleinfo->groupingid = 0;
         $moduleinfo->availability = $availability;
-        $moduleinfo->completion = 0;
+        $moduleinfo->completion = $CFG->completiondefault;
 
         // Populate the modinfo object with opencast activity specific parameters.
         $moduleinfo->type = $type;

--- a/classes/local/ltimodulemanager.php
+++ b/classes/local/ltimodulemanager.php
@@ -365,6 +365,8 @@ class ltimodulemanager
      */
     public static function build_lti_modinfo($pluginid, $title, $sectionid, $toolid, $instructorcustomparameters, $introtext = '',
                                              $introformat = FORMAT_HTML, $availability = null) {
+        global $CFG;
+
         // Create standard class object.
         $moduleinfo = new \stdClass();
 
@@ -386,7 +388,7 @@ class ltimodulemanager
         $moduleinfo->groupmode = NOGROUPS;
         $moduleinfo->groupingid = 0;
         $moduleinfo->availability = $availability;
-        $moduleinfo->completion = 0;
+        $moduleinfo->completion = $CFG->completiondefault;
 
         // Populate the modinfo object with LTI specific parameters.
         $moduleinfo->typeid = $toolid;


### PR DESCRIPTION
Before this patch, even if the default in $CFG->completiondefault was set to "Use activity default", the created Opencast activities always used "Do not indicate activity completion".

This patch changes this shortcoming in a way that the Opencast module creation process will now respect and use the $CFG->completiondefault setting for completion tracking.