### PR TITLE
Pre-fill activity descriptions with existing episode descriptions - Solves #196.

### DIFF
--- a/classes/local/activitymodulemanager.php
+++ b/classes/local/activitymodulemanager.php
@@ -342,6 +342,44 @@ class activitymodulemanager
     }
 
     /**
+     * Helperfunction to get the default intro for a particular Opencast Activity episode module.
+     *
+     * @param string $episodeuuid
+     *
+     * @return string
+     */
+    public static function get_default_intro_for_episode($episodeuuid) {
+        // Get an APIbridge instance.
+        $apibridge = \block_opencast\local\apibridge::get_instance();
+
+        // Get the episode information.
+        $info = $apibridge->get_opencast_video($episodeuuid);
+
+        // If we did get an error from the APIbridge, there is probably something wrong.
+        // However, it's not our job to solve this here. We just have to provide a default intro.
+        // Thus, let's return an empty string.
+        if ($info->error != 0) {
+            return '';
+        }
+
+        // Pick the video description from the information object.
+        $episodeintro = $info->video->description;
+
+        // Check if the episode intro is empty. This isn't a problem.
+        // Thus, let's return an empty string.
+        if (empty($episodeintro) || $episodeintro == '') {
+            return '';
+        }
+
+        // As the Opencast video description is a plain-text field which might contain line breaks anyway,
+        // thus insert HTML line breaks.
+        $episodeintro = nl2br($episodeintro);
+
+        // Finally, return the episode intro.
+        return $episodeintro;
+    }
+
+    /**
      * Helperfunction to get the section list of a given course as associative array.
      * This includes a fallback for the case that the course format does not use sections at all.
      *

--- a/classes/local/addactivityepisode_form.php
+++ b/classes/local/addactivityepisode_form.php
@@ -62,6 +62,10 @@ class addactivityepisode_form extends \moodleform
                 array('rows' => 5),
                 array('maxfiles' => 0, 'noclean' => true));
             $mform->setType('intro', PARAM_RAW); // No XSS prevention here, users must be trusted.
+            $mform->setDefault('intro',
+                array('text' =>
+                    \block_opencast\local\activitymodulemanager::get_default_intro_for_episode($this->_customdata['episodeuuid']),
+                    'format' => FORMAT_HTML));
         }
 
         if (get_config('block_opencast', 'addactivityepisodesection') == true) {

--- a/classes/local/addltiepisode_form.php
+++ b/classes/local/addltiepisode_form.php
@@ -61,6 +61,10 @@ class addltiepisode_form extends \moodleform
                 array('rows' => 5),
                 array('maxfiles' => 0, 'noclean' => true));
             $mform->setType('intro', PARAM_RAW); // No XSS prevention here, users must be trusted.
+            $mform->setDefault('intro',
+                array('text' =>
+                    \block_opencast\local\ltimodulemanager::get_default_intro_for_episode($this->_customdata['episodeuuid']),
+                    'format' => FORMAT_HTML));
         }
 
         if (get_config('block_opencast', 'addltiepisodesection') == true) {

--- a/classes/local/ltimodulemanager.php
+++ b/classes/local/ltimodulemanager.php
@@ -898,6 +898,44 @@ class ltimodulemanager
     }
 
     /**
+     * Helperfunction to get the default intro for a particular Opencast LTI episode module.
+     *
+     * @param string $episodeuuid
+     *
+     * @return string
+     */
+    public static function get_default_intro_for_episode($episodeuuid) {
+        // Get an APIbridge instance.
+        $apibridge = \block_opencast\local\apibridge::get_instance();
+
+        // Get the episode information.
+        $info = $apibridge->get_opencast_video($episodeuuid);
+
+        // If we did get an error from the APIbridge, there is probably something wrong.
+        // However, it's not our job to solve this here. We just have to provide a default intro.
+        // Thus, let's return an empty string.
+        if ($info->error != 0) {
+            return '';
+        }
+
+        // Pick the video description from the information object.
+        $episodeintro = $info->video->description;
+
+        // Check if the episode intro is empty. This isn't a problem.
+        // Thus, let's return an empty string.
+        if (empty($episodeintro) || $episodeintro == '') {
+            return '';
+        }
+
+        // As the Opencast video description is a plain-text field which might contain line breaks anyway,
+        // thus insert HTML line breaks.
+        $episodeintro = nl2br($episodeintro);
+
+        // Finally, return the episode intro.
+        return $episodeintro;
+    }
+
+    /**
      * Helperfunction to get the section list of a given course as associative array.
      * This includes a fallback for the case that the course format does not use sections at all.
      *


### PR DESCRIPTION
When uploading a video on addvideo.php (and if configured properly by the Moodle admin), teachers can not only an episode title but also a episode description within the episode metadata.
Additionally, when providing the episode as (LTI or mod_opencast) activity to the students, the teacher can again add a description.

This patch adds the behaviour that an existing description from the episode metadata will be pre-filled into the activity description field.