### PR TITLE
casting maxbytes to int for chunkupload elements

### DIFF
--- a/classes/local/addvideo_form.php
+++ b/classes/local/addvideo_form.php
@@ -144,7 +144,7 @@ class addvideo_form extends \moodleform
             }
         }
 
-        $maxuploadsize = get_config('block_opencast', 'uploadfilelimit');
+        $maxuploadsize = (int) get_config('block_opencast', 'uploadfilelimit');
 
         $presenterdesc = \html_writer::tag('p', get_string('presenterdesc', 'block_opencast'));
         $mform->addElement('html', $presenterdesc);


### PR DESCRIPTION
Since https://github.com/Opencast-Moodle/moodle-local_chunkupload/commit/a955d12b44457ea934df67d8ad2e2863a66a6329 local_chunkupload now requires the maxbytes passed to it to be an integer. So we just cast it to an integer after fetching it from the DB (via get_config) where it's stored as a string.