### PR TITLE
Fix fatal regression with changing video visibility

### DIFF
--- a/classes/local/visibility_form.php
+++ b/classes/local/visibility_form.php
@@ -62,6 +62,9 @@ class visibility_form extends \moodleform
 
         $mform->addElement('hidden', 'identifier', $eventid);
         $mform->setType('identifier', PARAM_INT);
+        
+        $mform->addElement('hidden', 'ocinstanceid', $ocinstanceid);
+        $mform->setType('ocinstanceid', PARAM_INT);
 
         // Check if the teacher should be allowed to restrict the episode to course groups.
         $controlgroupsenabled = get_config('block_opencast', 'aclcontrolgroup_' . $ocinstanceid);


### PR DESCRIPTION
This patch fixes a fatal regression with changing the video visibility feature which broke when the multiple-instance feature was integrated.