### PR TITLE
OC Editor integration

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -1656,6 +1656,25 @@ class apibridge
     }
 
     /**
+     * The allowance of using the opencast editor.
+     * @param object $video Opencast video
+     * @param int $courseid Course id
+     * @return bool the capability of updating!
+     */
+    public function can_edit_event_in_editor($video, $courseid) {
+
+        if (get_config('block_opencast', 'enable_opencast_editor_link_' . $this->ocinstanceid) &&
+            !empty(get_config('block_opencast', 'editorlticonsumerkey_'. $this->ocinstanceid)) &&
+            !empty(get_config('block_opencast', 'editorlticonsumersecret_'. $this->ocinstanceid)) &&
+            isset($video->processing_state) && $video->processing_state == "SUCCEEDED") {
+            $context = \context_course::instance($courseid);
+            return has_capability('block/opencast:addvideo', $context);
+        }
+
+        return false;
+    }
+
+    /**
      * Get the event's metadata of the specified type
      * @param string $eventidentifier Event id
      * @param string $query Api query additions

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -1663,10 +1663,13 @@ class apibridge
      */
     public function can_edit_event_in_editor($video, $courseid) {
 
+        // We check if the basic editor integration configs are set, the video processing state is succeeded (to avoid process failure)
+        // and there is internal publication status (to avoid error 400 in editor).
         if (get_config('block_opencast', 'enable_opencast_editor_link_' . $this->ocinstanceid) &&
             !empty(get_config('block_opencast', 'editorlticonsumerkey_'. $this->ocinstanceid)) &&
             !empty(get_config('block_opencast', 'editorlticonsumersecret_'. $this->ocinstanceid)) &&
-            isset($video->processing_state) && $video->processing_state == "SUCCEEDED") {
+            isset($video->processing_state) && $video->processing_state == "SUCCEEDED" &&
+            isset($video->publication_status) && is_array($video->publication_status) && in_array('internal', $video->publication_status)) {
             $context = \context_course::instance($courseid);
             return has_capability('block/opencast:addvideo', $context);
         }

--- a/index.php
+++ b/index.php
@@ -397,8 +397,9 @@ foreach ($seriesvideodata as $series => $videodata) {
 
                 // Actions column.
                 $updatemetadata = $opencast->can_update_event_metadata($video, $courseid);
+                $useeditor = $opencast->can_edit_event_in_editor($video, $courseid);
                 $actions .= $renderer->render_edit_functions($ocinstanceid, $courseid, $video->identifier, $updatemetadata,
-                    $workflowsavailable, $coursecontext);
+                    $workflowsavailable, $coursecontext, $useeditor);
 
                 if (has_capability('block/opencast:downloadvideo', $coursecontext) && $video->is_downloadable) {
                     $actions .= $renderer->render_download_event_icon($ocinstanceid, $courseid, $video);

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -645,5 +645,21 @@ $string['workflow_not_existing'] = 'This workflow does not exist in Opencast.';
 $string['wrongmimetypedetected'] = 'An invalid mimetype was used while uploading the video {$a->filename} from course {$a->coursename}.
     Only video files are allowed!';
 
+// Opencast Editor Integration strings.
+$string['videoeditor_short'] = 'Video Editor';
+$string['videoeditorinvalidconfig'] = 'Currently, it is not possible to use Opencast Editor in order to edit the event.';
+$string['opencasteditorintegration'] = 'Opencast Editor integration';
+$string['enableopencasteditorlink'] = 'Show the link to opencast Editor in action menu';
+$string['enableopencasteditorlink_desc'] = 'This option renders a button to opencast editor in the block content and the block overview.
+ The following settings as well lti credentials have to be configured as well.';
+$string['editorbaseurl'] = 'Opencast Editor Base URL';
+$string['editorbaseurl_desc'] = 'The base URL to be used to call the Opencast Editor, the base url of the opencast instance is used if empty.';
+$string['editorendpointurl'] = 'Opencast Editor Endpoint';
+$string['editorendpointurl_desc'] = 'The editor endpoint to access the editor. The mediapackage ID will be added at the end of the url.';
+$string['editorlticonsumerkey'] = 'Opencast Editor Consumer key';
+$string['editorlticonsumerkey_desc'] = 'LTI Consumer key for the opencast editor integration.';
+$string['editorlticonsumersecret'] = 'Opencast Editor Consumer secret';
+$string['editorlticonsumersecret_desc'] = 'LTI Consumer secret for the opencast editor integration.';
+
 // Deprecated since version 2021062300.
 $string['video_already_uploaded'] = 'Video already uploaded';

--- a/renderer.php
+++ b/renderer.php
@@ -637,7 +637,7 @@ class block_opencast_renderer extends plugin_renderer_base
         return \html_writer::link($url, $icon);
     }
 
-    public function render_edit_functions($ocinstanceid, $courseid, $videoidentifier, $updatemetadata, $startworkflows, $coursecontext) {
+    public function render_edit_functions($ocinstanceid, $courseid, $videoidentifier, $updatemetadata, $startworkflows, $coursecontext, $useeditor) {
         // Get the action menu options.
         $actionmenu = new action_menu();
         $actionmenu->set_alignment(action_menu::TL, action_menu::BL);
@@ -651,6 +651,16 @@ class block_opencast_renderer extends plugin_renderer_base
                     array('video_identifier' => $videoidentifier, 'courseid' => $courseid, 'ocinstanceid' => $ocinstanceid)),
                 new pix_icon('t/editstring', get_string('updatemetadata_short', 'block_opencast')),
                 get_string('updatemetadata_short', 'block_opencast')
+            ));
+        }
+
+        if ($useeditor) {
+            $actionmenu->add(new action_menu_link_secondary(
+                new \moodle_url('/blocks/opencast/videoeditor.php',
+                    array('video_identifier' => $videoidentifier, 'courseid' => $courseid, 'ocinstanceid' => $ocinstanceid)),
+                new pix_icon('e/cut', get_string('ocstateneedscutting', 'block_opencast')),
+                get_string('videoeditor_short', 'block_opencast'),
+                ['target' => '_blank']
             ));
         }
 

--- a/settings.php
+++ b/settings.php
@@ -415,6 +415,42 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                     get_string('lticonsumersecret', 'block_opencast'),
                     get_string('lticonsumersecret_desc', 'block_opencast'), ""));
 
+            // Opencast Editor Integration in additional feature settings.
+            $additionalsettings->add(
+                new admin_setting_heading('block_opencast/opencast_videoeditor_' . $instance->id,
+                    get_string('opencasteditorintegration', 'block_opencast'),
+                    ''));
+
+            // The Generall Integration Permission.
+            $additionalsettings->add(
+                new admin_setting_configcheckbox('block_opencast/enable_opencast_editor_link_' . $instance->id,
+                    get_string('enableopencasteditorlink', 'block_opencast'),
+                    get_string('enableopencasteditorlink_desc', 'block_opencast'), 0));
+
+            // The External base url to call editor (if any). The opencast instance URL will be used if empty.
+            $additionalsettings->add(
+                new admin_setting_configtext('block_opencast/editorbaseurl_' . $instance->id,
+                    get_string('editorbaseurl', 'block_opencast'),
+                    get_string('editorbaseurl_desc', 'block_opencast'), ""));
+            
+            // The Editor endpoint url. It defines where to look for the editor in base url.
+            $additionalsettings->add(
+                new admin_setting_configtext('block_opencast/editorendpointurl_' . $instance->id,
+                    get_string('editorendpointurl', 'block_opencast'),
+                    get_string('editorendpointurl_desc', 'block_opencast'), "/editor-ui/index.html?mediaPackageId="));
+            
+            // LTI Consumer Key for the editor alone.
+            $additionalsettings->add(
+                new admin_setting_configtext('block_opencast/editorlticonsumerkey_' . $instance->id,
+                    get_string('editorlticonsumerkey', 'block_opencast'),
+                    get_string('editorlticonsumerkey_desc', 'block_opencast'), ""));
+
+            // LTI Consumer Secret for the editor alone.
+            $additionalsettings->add(
+                new admin_setting_configpasswordunmask('block_opencast/editorlticonsumersecret_' . $instance->id,
+                    get_string('editorlticonsumersecret', 'block_opencast'),
+                    get_string('editorlticonsumersecret_desc', 'block_opencast'), ""));
+            
             // Notifications in additional features settings.
             $additionalsettings->add(
                 new admin_setting_heading('block_opencast/notifications_' . $instance->id,

--- a/videoeditor.php
+++ b/videoeditor.php
@@ -1,0 +1,158 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Redirects users to Opencast Studio for recording videos.
+ * @package    block_opencast
+ * @copyright  2020 Farbod Zamani Boroujeni - ELAN e.V.
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+require_once('../../config.php');
+require_once($CFG->dirroot . '/mod/lti/locallib.php');
+require_once($CFG->dirroot . '/lib/oauthlib.php');
+
+use block_opencast\local\upload_helper;
+
+global $PAGE, $OUTPUT, $CFG, $USER;
+
+require_once($CFG->dirroot . '/repository/lib.php');
+
+$identifier = required_param('video_identifier', PARAM_ALPHANUMEXT);
+$courseid = required_param('courseid', PARAM_INT);
+$ocinstanceid = optional_param('ocinstanceid', \tool_opencast\local\settings_api::get_default_ocinstance()->id, PARAM_INT);
+
+$redirecturl = new moodle_url('/blocks/opencast/index.php', array('courseid' => $courseid, 'ocinstanceid' => $ocinstanceid));
+$baseurl = new moodle_url('/blocks/opencast/videoeditor.php', array('video_identifier' => $identifier, 'courseid' => $courseid, 'ocinstanceid' => $ocinstanceid));
+$PAGE->set_url($baseurl);
+
+require_login($courseid, false);
+
+// Capability check.
+$context = context_course::instance($courseid);
+require_capability('block/opencast:addvideo', $context);
+
+$PAGE->set_context($context);
+
+$PAGE->set_pagelayout('incourse');
+$PAGE->set_title(get_string('videoeditor_short', 'block_opencast'));
+$PAGE->set_heading(get_string('pluginname', 'block_opencast'));
+
+$endpoint = \tool_opencast\local\settings_api::get_apiurl($ocinstanceid);
+
+$editorendpoint = get_config('block_opencast', 'editorendpointurl_' . $ocinstanceid);
+if (empty($editorendpoint)) {
+    $editorendpoint = '/editor-ui/index.html?mediaPackageId=';
+}
+
+$editorendpoint = '/' . ltrim($editorendpoint, '/') . $identifier;
+
+$editorbaseurl = get_config('block_opencast', 'editorbaseurl_' . $ocinstanceid);
+if (empty($editorbaseurl)) {
+    $editorbaseurl = $endpoint;
+}
+
+if (strpos($editorbaseurl, 'http') !== 0) {
+    $editorbaseurl = 'http://' . $editorbaseurl;
+}
+
+$ltiendpoint = rtrim($editorbaseurl, '/') . '/lti';
+
+$opencast = \block_opencast\local\apibridge::get_instance($ocinstanceid);
+$video = $opencast->get_opencast_video($identifier);
+
+// Validate the video and make sure the video can be edited by the editor (double check).
+if ((empty($editorbaseurl) || empty($editorendpoint) || !$video || $video->error == true || !$opencast->can_edit_event_in_editor($video->video, $courseid))) {
+    redirect($redirecturl, get_string('videoeditorinvalidconfig', 'block_opencast'), null, \core\output\notification::NOTIFY_ERROR);
+}
+
+// Create parameters.
+$params = block_opencast_create_editor_lti_parameters($ocinstanceid, $ltiendpoint, $editorendpoint);
+
+$renderer = $PAGE->get_renderer('block_opencast');
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('videoeditor_short', 'block_opencast'));
+echo $renderer->render_lti_form($ltiendpoint, $params);
+
+$PAGE->requires->js_call_amd('block_opencast/block_lti_form_handler', 'init');
+echo $OUTPUT->footer();
+
+/**
+ * Create necessary editor lti parameters.
+ * @param string $endpoint of the opencast instance.
+ * @param string $seriesid id of the series, to which recordings should be uploaded.
+ * @param string $customtool the custom tool to used in order to redirect after lti authentication.
+ *
+ * @return array lti parameters
+ * @throws dml_exception
+ * @throws moodle_exception
+ */
+function block_opencast_create_editor_lti_parameters($ocinstanceid, $endpoint, $customtool) {
+    global $CFG, $COURSE, $USER;
+
+    // Get consumerkey and consumersecret.
+    $consumerkey = get_config('block_opencast', 'editorlticonsumerkey_'. $ocinstanceid);
+    $consumersecret = get_config('block_opencast', 'editorlticonsumersecret_' . $ocinstanceid);
+
+    $helper = new oauth_helper(array('oauth_consumer_key'    => $consumerkey,
+                                    'oauth_consumer_secret' => $consumersecret));
+
+    // Set all necessary parameters.
+    $params = array();
+    $params['oauth_version'] = '1.0';
+    $params['oauth_nonce'] = $helper->get_nonce();
+    $params['oauth_timestamp'] = $helper->get_timestamp();
+    $params['oauth_consumer_key'] = $consumerkey;
+
+    $params['context_id'] = $COURSE->id;
+    $params['context_label'] = trim($COURSE->shortname);
+    $params['context_title'] = trim($COURSE->fullname);
+    $params['resource_link_id'] = 'o' . random_int(1000, 9999) . '-' . random_int(1000, 9999);
+    $params['resource_link_title'] = 'Opencast';
+    $params['context_type'] = ($COURSE->format == 'site') ? 'Group' : 'CourseSection';
+    $params['launch_presentation_locale'] = current_language();
+    $params['ext_lms'] = 'moodle-2';
+    $params['tool_consumer_info_product_family_code'] = 'moodle';
+    $params['tool_consumer_info_version'] = strval($CFG->version);
+    $params['oauth_callback'] = 'about:blank';
+    $params['lti_version'] = 'LTI-1p0';
+    $params['lti_message_type'] = 'basic-lti-launch-request';
+    $urlparts = parse_url($CFG->wwwroot);
+    $params['tool_consumer_instance_guid'] = $urlparts['host'];
+    $params['custom_tool'] = $customtool;
+
+    // User data.
+    $params['user_id'] = $USER->id;
+    $params['lis_person_name_given'] = $USER->firstname;
+    $params['lis_person_name_family'] = $USER->lastname;
+    $params['lis_person_name_full'] = $USER->firstname . ' ' . $USER->lastname;
+    $params['ext_user_username'] = $USER->username;
+    $params['lis_person_contact_email_primary'] = $USER->email;
+    $params['roles'] = lti_get_ims_role($USER, null, $COURSE->id, false);
+
+    if (!empty($CFG->mod_lti_institution_name)) {
+        $params['tool_consumer_instance_name'] = trim(html_to_text($CFG->mod_lti_institution_name, 0));
+    } else {
+        $params['tool_consumer_instance_name'] = get_site()->shortname;
+    }
+
+    $params['launch_presentation_document_target'] = 'iframe';
+    $params['oauth_signature_method'] = 'HMAC-SHA1';
+    $signedparams = lti_sign_parameters($params, $endpoint, "POST", $consumerkey, $consumersecret);
+    $params['oauth_signature'] = $signedparams['oauth_signature'];
+
+    return $params;
+}


### PR DESCRIPTION
This patch integrates the stand alone OC-Editor into the moodle-block_opencast plugin via LTI and redirect.
This fixes #98 

A new section "Opencast Editor integration" is added to the "Additional Feature" config setting.
A new action button is added into the action dropdown menu inside opencast video overview, called "Video Editor" right after "Update metadata".
There are new language strings related to the changes.

**To use this patch, you would need to...**

-  use the latest version of moodle-tool_opencast, which support multiple OC instances.
-  set LTI credentials for the Editor Integration in setting.
-  make sure event (Video) is successfully processed.
-  make sure event (Video) has internal publication.
-  make sure new language strings are applied.