### PR TITLE
Access video static file from video list

### DIFF
--- a/accessvideo.php
+++ b/accessvideo.php
@@ -60,7 +60,10 @@ $video = $apibridge->get_opencast_video($identifier);
 
 // Check if the access to the video static file is possible.
 if (!$apibridge->can_access_video_static_file($video->video, $courseid)) {
-    redirect($redirecturl, get_string('staticvideofileinvalidconfig', 'block_opencast'), null, \core\output\notification::NOTIFY_ERROR);
+    redirect($redirecturl,
+        get_string('staticvideofileinvalidconfig', 'block_opencast'),
+        null,
+        \core\output\notification::NOTIFY_ERROR);
 }
 
 // Get the search service from the opencast instance.
@@ -68,7 +71,10 @@ $searchservice = $apibridge->get_services('search');
 
 // Check if the search service is available.
 if (!$searchservice) {
-    redirect($redirecturl, get_string('staticvideofilenosearchservice', 'block_opencast'), null, \core\output\notification::NOTIFY_ERROR);
+    redirect($redirecturl,
+        get_string('staticvideofilenosearchservice', 'block_opencast'),
+        null,
+        \core\output\notification::NOTIFY_ERROR);
 }
 
 // Create custom configs to get a custom instance from tool_opencast\local\api.
@@ -87,7 +93,10 @@ $searchresult = json_decode($searchapiinstance->oc_get($url), true);
 
 // Check if the search call is successful, if not show an error message.
 if ($searchapiinstance->get_http_code() != 200) {
-    redirect($redirecturl, get_string('staticvideofilefailedtogetvideodata', 'block_opencast'), null, \core\output\notification::NOTIFY_ERROR);
+    redirect($redirecturl,
+        get_string('staticvideofilefailedtogetvideodata', 'block_opencast'),
+        null,
+        \core\output\notification::NOTIFY_ERROR);
 }
 
 // Extract the tracks from mediapackage.
@@ -97,7 +106,10 @@ $tracks = (isset($searchresult['search-results']['result']) ?
 
 // Check if there is any video track.
 if (empty($tracks)) {
-    redirect($redirecturl, get_string('staticvideofilenovideotrack', 'block_opencast'), null, \core\output\notification::NOTIFY_ERROR);
+    redirect($redirecturl,
+        get_string('staticvideofilenovideotrack', 'block_opencast'),
+        null,
+        \core\output\notification::NOTIFY_ERROR);
 }
 
 $videotracks = [];

--- a/accessvideo.php
+++ b/accessvideo.php
@@ -1,0 +1,235 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Redirects users to video file after evaluation.
+ * It redirects directly to the video static file, when LTI configs are not set.
+ * By providing LTI configs, the LTI authentication will be performed to access the video static file.
+ * @package    block_opencast
+ * @copyright  2021 Farbod Zamani Boroujeni - ELAN e.V.
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+require_once('../../config.php');
+require_once($CFG->dirroot . '/mod/lti/locallib.php');
+require_once($CFG->dirroot . '/lib/oauthlib.php');
+
+global $PAGE, $OUTPUT, $CFG, $USER;
+
+// Get all the params from the get call.
+$identifier = required_param('identifier', PARAM_ALPHANUMEXT);
+$courseid = required_param('courseid', PARAM_INT);
+$ocinstanceid = optional_param('ocinstanceid', \tool_opencast\local\settings_api::get_default_ocinstance()->id, PARAM_INT);
+
+// Preparing the urls for the page.
+$redirecturl = new moodle_url('/blocks/opencast/index.php', array('courseid' => $courseid, 'ocinstanceid' => $ocinstanceid));
+$baseurl = new moodle_url('/blocks/opencast/accessvideo.php',
+    array('identifier' => $identifier, 'courseid' => $courseid, 'ocinstanceid' => $ocinstanceid));
+$PAGE->set_url($baseurl);
+
+// Check if the user is logged in.
+require_login($courseid, false);
+
+// Get the context of the course.
+$context = context_course::instance($courseid);
+
+// Preparing the page.
+$PAGE->set_context($context);
+
+$PAGE->set_pagelayout('incourse');
+$PAGE->set_title(get_string('staticvideofilelink_short', 'block_opencast'));
+$PAGE->set_heading(get_string('pluginname', 'block_opencast'));
+
+// Get the apibrdge instance.
+$apibridge = \block_opencast\local\apibridge::get_instance($ocinstanceid);
+
+// Get the video object.
+$video = $apibridge->get_opencast_video($identifier);
+
+// Check if the access to the video static file is possible.
+if (!$apibridge->can_access_video_static_file($video->video, $courseid)) {
+    redirect($redirecturl, get_string('staticvideofileinvalidconfig', 'block_opencast'), null, \core\output\notification::NOTIFY_ERROR);
+}
+
+// Get the search service from the opencast instance.
+$searchservice = $apibridge->get_services('search');
+
+// Check if the search service is available.
+if (!$searchservice) {
+    redirect($redirecturl, get_string('staticvideofilenosearchservice', 'block_opencast'), null, \core\output\notification::NOTIFY_ERROR);
+}
+
+// Create custom configs to get a custom instance from tool_opencast\local\api.
+$customconfigs = [
+    'apiurl' => preg_replace(["/\/docs/"], [''], $searchservice->host)
+];
+
+// Get custom instance from tool_opencast\local\api.
+$searchapiinstance = $apibridge->get_customized_api_instance($customconfigs);
+
+// Prepare the endpoint url to get data from search service.
+$url = '/search/episode.json?id=' . $identifier;
+
+// Make the get request to the search service.
+$searchresult = json_decode($searchapiinstance->oc_get($url), true);
+
+// Check if the search call is successful, if not show an error message.
+if ($searchapiinstance->get_http_code() != 200) {
+    redirect($redirecturl, get_string('staticvideofilefailedtogetvideodata', 'block_opencast'), null, \core\output\notification::NOTIFY_ERROR);
+}
+
+// Extract the tracks from mediapackage.
+$tracks = (isset($searchresult['search-results']['result']) ?
+    $searchresult['search-results']['result']['mediapackage']['media']['track'] :
+    null);
+
+// Check if there is any video track.
+if (empty($tracks)) {
+    redirect($redirecturl, get_string('staticvideofilenovideotrack', 'block_opencast'), null, \core\output\notification::NOTIFY_ERROR);
+}
+
+$videotracks = [];
+// If there is video key inside the tracks array, that means it is a single track.
+if (array_key_exists('video', $tracks)) {
+    if (strpos($tracks['mimetype'], 'video') !== false) {
+        $videotracks[] = $tracks;
+    }
+} else {
+    // Otherwise, there are more than one track.
+    // Extract videos from tracks.
+    $videotracks = array_filter($tracks, function($track) {
+        return strpos($track['mimetype'], 'video') !== false;
+    });
+}
+
+// Get the url of video track with the highest resolution.
+$url = '';
+$resolutions = array_column(array_column($videotracks, 'video'), 'resolution');
+$bestresolution = 0;
+foreach ($resolutions as $index => $resolution) {
+    // Get the numbers from the resolution.
+    $resolutionarray = explode('x', $resolution);
+    // Multiplication.
+    $resolutionproduct = array_product($resolutionarray);
+    // Check if the resoluton is greater than the last one, to set the url.
+    if ($bestresolution < $resolutionproduct) {
+        $url = $videotracks[$index]['url'];
+        $bestresolution = $resolutionproduct;
+    }
+}
+
+// If url is empty, we assume that there is no resolution available,
+// then we get the url of the first element in the $videotracks array.
+if (empty($url)) {
+    $url = $videotracks[0]['url'];
+}
+
+// If LTI config is not set, it redirects the user to the video url, and let the opencast handle the authentication itself.
+if (empty(get_config('block_opencast', 'staticvideofilelticonsumerkey_' . $ocinstanceid))) {
+    redirect($url);
+}
+
+// Get the LTI endpoint.
+$endpoint = $searchservice->host;
+
+// Make sure the endpoint is correct.
+if (strpos($endpoint, 'http') !== 0) {
+    $endpoint = 'http://' . $endpoint;
+}
+
+// Create the LTI endpoint from the api url of the oc instance.
+$ltiendpoint = rtrim($endpoint, '/') . '/lti';
+
+// Create the customtools url.
+$customtool = str_replace($searchservice->host, '', $url);
+
+// Create parameters.
+$params = block_opencast_create_video_static_file_lti_parameters($ocinstanceid, $ltiendpoint, $customtool);
+
+$renderer = $PAGE->get_renderer('block_opencast');
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('staticvideofilelink_short', 'block_opencast'));
+echo $renderer->render_lti_form($ltiendpoint, $params);
+
+$PAGE->requires->js_call_amd('block_opencast/block_lti_form_handler', 'init');
+echo $OUTPUT->footer();
+
+/**
+ * Create necessary lti parameters to access video static file.
+ * @param string $endpoint of the opencast instance.
+ * @param string $seriesid id of the series, to which recordings should be uploaded.
+ * @param string $customtool the custom tool to used in order to redirect after lti authentication.
+ *
+ * @return array lti parameters
+ * @throws dml_exception
+ * @throws moodle_exception
+ */
+function block_opencast_create_video_static_file_lti_parameters($ocinstanceid, $endpoint, $customtool) {
+    global $CFG, $COURSE, $USER;
+
+    // Get consumerkey and consumersecret.
+    $consumerkey = get_config('block_opencast', 'staticvideofilelticonsumerkey_' . $ocinstanceid);
+    $consumersecret = get_config('block_opencast', 'staticvideofilelticonsumersecret_' . $ocinstanceid);
+
+    $helper = new oauth_helper(array('oauth_consumer_key' => $consumerkey,
+        'oauth_consumer_secret' => $consumersecret));
+
+    // Set all necessary parameters.
+    $params = array();
+    $params['oauth_version'] = '1.0';
+    $params['oauth_nonce'] = $helper->get_nonce();
+    $params['oauth_timestamp'] = $helper->get_timestamp();
+    $params['oauth_consumer_key'] = $consumerkey;
+
+    $params['context_id'] = $COURSE->id;
+    $params['context_label'] = trim($COURSE->shortname);
+    $params['context_title'] = trim($COURSE->fullname);
+    $params['resource_link_id'] = 'o' . random_int(1000, 9999) . '-' . random_int(1000, 9999);
+    $params['resource_link_title'] = 'Opencast';
+    $params['context_type'] = ($COURSE->format == 'site') ? 'Group' : 'CourseSection';
+    $params['launch_presentation_locale'] = current_language();
+    $params['ext_lms'] = 'moodle-2';
+    $params['tool_consumer_info_product_family_code'] = 'moodle';
+    $params['tool_consumer_info_version'] = strval($CFG->version);
+    $params['oauth_callback'] = 'about:blank';
+    $params['lti_version'] = 'LTI-1p0';
+    $params['lti_message_type'] = 'basic-lti-launch-request';
+    $urlparts = parse_url($CFG->wwwroot);
+    $params['tool_consumer_instance_guid'] = $urlparts['host'];
+    $params['custom_tool'] = $customtool;
+
+    // User data.
+    $params['user_id'] = $USER->id;
+    $params['lis_person_name_given'] = $USER->firstname;
+    $params['lis_person_name_family'] = $USER->lastname;
+    $params['lis_person_name_full'] = $USER->firstname . ' ' . $USER->lastname;
+    $params['ext_user_username'] = $USER->username;
+    $params['lis_person_contact_email_primary'] = $USER->email;
+    $params['roles'] = lti_get_ims_role($USER, null, $COURSE->id, false);
+
+    if (!empty($CFG->mod_lti_institution_name)) {
+        $params['tool_consumer_instance_name'] = trim(html_to_text($CFG->mod_lti_institution_name, 0));
+    } else {
+        $params['tool_consumer_instance_name'] = get_site()->shortname;
+    }
+
+    $params['launch_presentation_document_target'] = 'iframe';
+    $params['oauth_signature_method'] = 'HMAC-SHA1';
+    $signedparams = lti_sign_parameters($params, $endpoint, "POST", $consumerkey, $consumersecret);
+    $params['oauth_signature'] = $signedparams['oauth_signature'];
+
+    return $params;
+}

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -137,7 +137,8 @@ class apibridge
         $allvideos = [];
 
         foreach ($series as $s) {
-            $query = 'sign=1&withacl=1&withmetadata=1&withpublications=1&sort=start_date:DESC&filter=' . urlencode("series:" . $s->series);
+            $query = 'sign=1&withacl=1&withmetadata=1&withpublications=1&sort=start_date:DESC&filter=' .
+                urlencode("series:" . $s->series);
 
             if (get_config('block_opencast', 'limitvideos_' . $this->ocinstanceid) > 0) {
                 // Try to fetch one more to decide whether display "more link" is necessary.

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -1705,7 +1705,7 @@ class apibridge
             isset($video->publication_status) && is_array($video->publication_status) &&
             in_array('engage-player', $video->publication_status)) {
             $context = \context_course::instance($courseid);
-            // Only enrolled users or admin are able to use this feature. 
+            // Only enrolled users or admin are able to use this feature.
             return (is_enrolled($context) || is_siteadmin($USER->id));
         }
 
@@ -2076,7 +2076,7 @@ class apibridge
 
         // If a single service is passed.
         if (!empty($services) && $findsingleservice) {
-            // Get the index of the service. 
+            // Get the index of the service.
             $serviceindex = array_search('/' . $findsingleservice, array_column($services, 'path'));
             // Extract and return the service array, if exists.
             return (isset($services[$serviceindex])) ? $services[$serviceindex] : null;
@@ -2088,7 +2088,7 @@ class apibridge
 
     /**
      * Create and return customized tool_opencast api instance.
-     * 
+     *
      * @param array $customconfigs the configs to created new api instance.
      * @return tool_opencast\local\api
      */
@@ -2125,7 +2125,7 @@ class apibridge
         if (!array_key_exists('apitimeout', $customconfigs)) {
             $customconfigs['apitimeout'] = $apitimeout;
         }
-        
+
         // Get customized API instance.
         $api = api::get_instance(null, [], $customconfigs);
 

--- a/index.php
+++ b/index.php
@@ -421,6 +421,11 @@ foreach ($seriesvideodata as $series => $videodata) {
                     $actions .= $renderer->render_download_event_icon($ocinstanceid, $courseid, $video);
                 }
 
+                // Check the capability to provide the button to access the video.
+                if ($opencast->can_access_video_static_file($video, $courseid)) {
+                    $actions .= $renderer->render_video_link_icon($ocinstanceid, $courseid, $video->identifier);
+                }
+
                 if ($opencast->can_delete_event_assignment($video, $courseid)) {
                     $actions .= $renderer->render_delete_event_icon($ocinstanceid, $courseid, $video->identifier);
                 }

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -663,5 +663,19 @@ $string['editorlticonsumerkey_desc'] = 'LTI Consumer key for the opencast editor
 $string['editorlticonsumersecret'] = 'Opencast Editor Consumer secret';
 $string['editorlticonsumersecret_desc'] = 'LTI Consumer secret for the opencast editor integration.';
 
+// Opencast Video Player strings.
+$string['staticvideofilelink_short'] = 'Link to video';
+$string['opencaststaticvideofilelink'] = 'Access Video static file';
+$string['enableopencaststaticvideofilelink'] = 'Show the link to access the video static file in action menu';
+$string['enableopencaststaticvideofilelink_desc'] = 'This option renders a button to access the video static file in opencast from the block content and the block overview.
+ In case the "Secure Static Files" option in opencast server is on, it is required to make LTI Authentication before accessing the video. That can be done via the following LTI settings.';
+$string['staticvideofilelticonsumerkey'] = 'LTI Consumer key to access video';
+$string['staticvideofilelticonsumerkey_desc'] = 'LTI Consumer key to access video static file via search node in case "Secure Static Files" is enabled';
+$string['staticvideofilelticonsumersecret'] = 'LTI Consumer secret to access video';
+$string['staticvideofilelticonsumersecret_desc'] = 'LTI Consumer secret to access video static file via search node in case "Secure Static Files" is enabled.';
+$string['staticvideofileinvalidconfig'] = 'Unable to access the video.';
+$string['staticvideofilenosearchservice'] = 'The presentation service is not available.';
+$string['staticvideofilefailedtogetvideodata'] = 'Unable to get video static file data.';
+$string['staticvideofilenovideotrack'] = 'Unable to find video data.';
 // Deprecated since version 2021062300.
 $string['video_already_uploaded'] = 'Video already uploaded';

--- a/renderer.php
+++ b/renderer.php
@@ -561,6 +561,24 @@ class block_opencast_renderer extends plugin_renderer_base
     }
 
     /**
+     * Render the link to access video static file.
+     *
+     * @param int $ocinstanceid
+     * @param int $courseid
+     * @param string $videoidentifier
+     */
+    public function render_video_link_icon($ocinstanceid, $courseid, $videoidentifier) {
+
+        $url = new \moodle_url('/blocks/opencast/accessvideo.php',
+            array('identifier' => $videoidentifier, 'courseid' => $courseid, 'ocinstanceid' => $ocinstanceid));
+        $text = get_string('staticvideofilelink_short', 'block_opencast');
+
+        $icon = $this->output->pix_icon('play', $text, 'block_opencast');
+
+        return \html_writer::link($url, $icon, ['target' => '_blank']);
+    }
+
+    /**
      * Render the link to delete a group assignment.
      *
      * @param string $videoidentifier

--- a/renderer.php
+++ b/renderer.php
@@ -579,7 +579,7 @@ class block_opencast_renderer extends plugin_renderer_base
             array('identifier' => $videoidentifier, 'courseid' => $courseid, 'ocinstanceid' => $ocinstanceid));
         $text = get_string('staticvideofilelink_short', 'block_opencast');
 
-        $icon = $this->output->pix_icon('play', $text, 'block_opencast');
+        $icon = $this->output->pix_icon('e/anchor', $text, 'moodle');
 
         return \html_writer::link($url, $icon, ['target' => '_blank']);
     }

--- a/settings.php
+++ b/settings.php
@@ -464,6 +464,30 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                 new admin_setting_configpasswordunmask('block_opencast/editorlticonsumersecret_' . $instance->id,
                     get_string('editorlticonsumersecret', 'block_opencast'),
                     get_string('editorlticonsumersecret_desc', 'block_opencast'), ""));
+            
+            // Opencast Video Player in additional feature settings.
+            $additionalsettings->add(
+                new admin_setting_heading('block_opencast/opencast_access_video_file_' . $instance->id,
+                    get_string('opencaststaticvideofilelink', 'block_opencast'),
+                    ''));
+
+            // The Generall player Permission.
+            $additionalsettings->add(
+                new admin_setting_configcheckbox('block_opencast/enable_opencast_access_video_file_link_' . $instance->id,
+                    get_string('enableopencaststaticvideofilelink', 'block_opencast'),
+                    get_string('enableopencaststaticvideofilelink_desc', 'block_opencast'), 0));
+
+            // LTI Consumer Key for the video player.
+            $additionalsettings->add(
+                new admin_setting_configtext('block_opencast/staticvideofilelticonsumerkey_' . $instance->id,
+                    get_string('staticvideofilelticonsumerkey', 'block_opencast'),
+                    get_string('staticvideofilelticonsumerkey_desc', 'block_opencast'), ""));
+
+            // LTI Consumer Secret for the video player.
+            $additionalsettings->add(
+                new admin_setting_configpasswordunmask('block_opencast/staticvideofilelticonsumersecret_' . $instance->id,
+                    get_string('staticvideofilelticonsumersecret', 'block_opencast'),
+                    get_string('staticvideofilelticonsumersecret_desc', 'block_opencast'), ""));
 
             // Notifications in additional features settings.
             $additionalsettings->add(

--- a/settings.php
+++ b/settings.php
@@ -464,7 +464,7 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                 new admin_setting_configpasswordunmask('block_opencast/editorlticonsumersecret_' . $instance->id,
                     get_string('editorlticonsumersecret', 'block_opencast'),
                     get_string('editorlticonsumersecret_desc', 'block_opencast'), ""));
-            
+
             // Opencast Video Player in additional feature settings.
             $additionalsettings->add(
                 new admin_setting_heading('block_opencast/opencast_access_video_file_' . $instance->id,

--- a/videoeditor.php
+++ b/videoeditor.php
@@ -15,16 +15,14 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Redirects users to Opencast Studio for recording videos.
+ * Redirects users to Opencast Editor.
  * @package    block_opencast
- * @copyright  2020 Farbod Zamani Boroujeni - ELAN e.V.
+ * @copyright  2021 Farbod Zamani Boroujeni - ELAN e.V.
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 require_once('../../config.php');
 require_once($CFG->dirroot . '/mod/lti/locallib.php');
 require_once($CFG->dirroot . '/lib/oauthlib.php');
-
-use block_opencast\local\upload_helper;
 
 global $PAGE, $OUTPUT, $CFG, $USER;
 


### PR DESCRIPTION
This PR fixes #58 and provides the feature to access the video static file in video list in a form of a button from within the video list. 
(NOT TESTED)
**Settings:** 
- A new section is introduced in admin settings under Additional features called "Access Video static file"
- Admin can enable/disable this feature.
- LTI Authentication settings are provided, in case the **Secure Static Files** setting is enabled.

**Usage**
- When the configuration and requirements are met, a button appears in the action column inside the Video list.
- The button redirects to a new page, in order to check the requirements and prepare the call to access the video static file.

**New functions**
- A new function to get and consume services of the opencast instance is introduced in apibridge class.
- A new function to create a customized tool_opencast api class is introduced in apibridge class.

**To improve**
- It might be useful to have a central config place to store LTI configs in order to use for different settings such as (Access video static file, Stand-alone Editor & Studio)