### PR TITLE
pass return params to Studio, fixes #152

### DIFF
--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -666,5 +666,15 @@ $string['editorlticonsumerkey_desc'] = 'LTI Consumer key for the opencast editor
 $string['editorlticonsumersecret'] = 'Opencast Editor Consumer secret';
 $string['editorlticonsumersecret_desc'] = 'LTI Consumer secret for the opencast editor integration.';
 
+// Strings fot new opencast studio settings.
+$string['opencaststudionewtab'] = 'Redirect to Studio in a new tab';
+$string['opencaststudionewtab_desc'] = 'When enabled, studio opens in a new tab.';
+$string['enableopencaststudioreturnbtn'] = 'Show a redirect back button in Studio';
+$string['enableopencaststudioreturnbtn_desc'] = 'When enabled, Studio then renders an additional button "Exit and go back" after up- or downloading the recording.';
+$string['opencaststudioreturnurl'] = 'Custom Studio return endpoint URL';
+$string['opencaststudioreturnurl_desc'] = 'When empty the return url redirects back to the same Moodle opencast block overview where the request comes from. A custom endpoint URL will then be passed to Studio as return url when configured, in this case, admin is able to use 2 placeholders including [OCINSTANCEID] and [COURSEID]. Please NOTE: the URL must be relative to wwwroot.';
+$string['opencaststudioreturnbtnlabel'] = 'Label for Studio\'s return button';
+$string['opencaststudioreturnbtnlabel_desc'] = 'This label works as a short description where the return link leads to. This label will be appended to the Studio return button text, when empty, moodle site name will be passed as label.';
+
 // Deprecated since version 2021062300.
 $string['video_already_uploaded'] = 'Video already uploaded';

--- a/recordvideo.php
+++ b/recordvideo.php
@@ -26,7 +26,7 @@ require_once($CFG->dirroot . '/lib/oauthlib.php');
 
 use block_opencast\local\upload_helper;
 
-global $PAGE, $OUTPUT, $CFG, $USER;
+global $PAGE, $OUTPUT, $CFG, $USER, $SITE;
 
 require_once($CFG->dirroot . '/repository/lib.php');
 
@@ -48,9 +48,9 @@ $PAGE->set_pagelayout('incourse');
 $PAGE->set_title(get_string('recordvideo', 'block_opencast'));
 $PAGE->set_heading(get_string('pluginname', 'block_opencast'));
 
-if (empty(get_config('block_opencast', 'opencast_studio_baseurl_' . $ocinstanceid))) {
-    $endpoint = \tool_opencast\local\settings_api::get_apiurl($ocinstanceid);
-} else {
+$endpoint = \tool_opencast\local\settings_api::get_apiurl($ocinstanceid);
+
+if (!empty(get_config('block_opencast', 'opencast_studio_baseurl_' . $ocinstanceid))) {
     $endpoint = get_config('block_opencast', 'opencast_studio_baseurl_' . $ocinstanceid);
 }
 
@@ -65,8 +65,59 @@ $api = \block_opencast\local\apibridge::get_instance($ocinstanceid);
 // Get series ID, create a new one if necessary.
 $seriesid = $api->get_stored_seriesid($courseid, true, $USER->id);
 
+// Create lti customtool to redirect to Studio.
+$customtoolparams = [];
+// Check if Studio return button is enabled.
+if (get_config('block_opencast', 'show_opencast_studio_return_btn_' . $ocinstanceid)) {
+    // Initializing default label for studio return button.
+    $studioreturnbtnlabel = $SITE->fullname;
+    // Check if custom label is configured.
+    if (!empty(get_config('block_opencast', 'opencast_studio_return_btn_label_' . $ocinstanceid))) {
+        $studioreturnbtnlabel = get_config('block_opencast', 'opencast_studio_return_btn_label_' . $ocinstanceid);
+    }
+
+    // Initializing default studio return url.
+    $studioreturnurl = new moodle_url('/blocks/opencast/index.php',
+        array('courseid' => $courseid, 'ocinstanceid' => $ocinstanceid));
+    // Check if custom return url is configured.
+    if (!empty(get_config('block_opencast', 'opencast_studio_return_url_' . $ocinstanceid))) {
+        // Prepare the custom url.
+        $customreturnurl = get_config('block_opencast', 'opencast_studio_return_url_' . $ocinstanceid);
+        // Slipt it into parts, to extract endpoint and query strings.
+        $customreturnurlarray = explode('?', $customreturnurl);
+        $customurl = $customreturnurlarray[0];
+        $customquerystring = count($customreturnurlarray) > 1 ? $customreturnurlarray[1] : null;
+
+        $customurldata = [];
+        // If there is any query string.
+        if (!empty($customquerystring)) {
+            // Split them.
+            $customquerystringdata = explode('&', $customquerystring);
+            // Put them into loop to replace the placeholders and add them into the customurldata array.
+            foreach ($customquerystringdata as $data) {
+                $datastring = str_replace(['[COURSEID]', '[OCINSTANCEID]'], [$courseid, $ocinstanceid], $data);
+                $dataarray = explode('=', $datastring);
+                if (count($dataarray) == 2) {
+                    $customurldata[$dataarray[0]] = $dataarray[1];
+                }
+            }
+        }
+
+        if (!empty($customurl)) {
+            $studioreturnurl = new moodle_url($customurl, $customurldata);
+        }
+    }
+
+    // Appending studio return data, only when there is a url.
+    if (!empty($studioreturnurl)) {
+        $customtoolparams[] = 'return.label=' . urlencode($studioreturnbtnlabel);
+        $customtoolparams[] = 'return.target=' . urlencode($studioreturnurl->out());
+    }
+}
+$customtoolparams[] = 'upload.seriesId=' . $seriesid;
+$customtool = '/studio?' . implode('&', $customtoolparams);
 // Create parameters.
-$params = block_opencast_create_lti_parameters($ocinstanceid, $ltiendpoint, $seriesid);
+$params = block_opencast_create_studio_lti_parameters($ocinstanceid, $ltiendpoint, $customtool);
 
 $renderer = $PAGE->get_renderer('block_opencast');
 
@@ -78,7 +129,7 @@ $PAGE->requires->js_call_amd('block_opencast/block_lti_form_handler', 'init');
 echo $OUTPUT->footer();
 
 /**
- * Create necessary lti parameters.
+ * Create necessary lti parameters for studio.
  * @param string $endpoint of the opencast instance.
  * @param string $seriesid id of the series, to which recordings should be uploaded.
  *
@@ -86,7 +137,7 @@ echo $OUTPUT->footer();
  * @throws dml_exception
  * @throws moodle_exception
  */
-function block_opencast_create_lti_parameters($ocinstanceid, $endpoint, $seriesid) {
+function block_opencast_create_studio_lti_parameters($ocinstanceid, $endpoint, $customtool) {
     global $CFG, $COURSE, $USER;
 
     // Get consumerkey and consumersecret.
@@ -118,7 +169,7 @@ function block_opencast_create_lti_parameters($ocinstanceid, $endpoint, $seriesi
     $params['lti_message_type'] = 'basic-lti-launch-request';
     $urlparts = parse_url($CFG->wwwroot);
     $params['tool_consumer_instance_guid'] = $urlparts['host'];
-    $params['custom_tool'] = '/studio?upload.seriesId=' . $seriesid;
+    $params['custom_tool'] = $customtool;
 
     // User data.
     $params['user_id'] = $USER->id;

--- a/renderer.php
+++ b/renderer.php
@@ -255,6 +255,12 @@ class block_opencast_renderer extends plugin_renderer_base
             $html .= html_writer::div($addvideobutton, 'opencast-addvideo-wrap overview');
 
             if (get_config('block_opencast', 'enable_opencast_studio_link_' . $ocinstance->id)) {
+                // Initialize the link target to open in the same tab.
+                $target = '_self';
+                // Check for the admin config to set the link target.
+                if (get_config('block_opencast', 'open_studio_in_new_tab_' . $ocinstance->id)) {
+                    $target = '_blank';
+                }
                 // If LTI credentials are given, use LTI. If not, directly forward to Opencast studio.
                 if (empty(get_config('block_opencast', 'lticonsumerkey_' . $ocinstance->id))) {
                     if (empty(get_config('block_opencast', 'opencast_studio_baseurl_' . $ocinstance->id))) {
@@ -270,13 +276,13 @@ class block_opencast_renderer extends plugin_renderer_base
                     $apibridge = apibridge::get_instance($ocinstance->id);
                     $url = $endpoint . '/studio?upload.seriesId=' . $apibridge->get_stored_seriesid($courseid, true, $USER->id);
                     $recordvideobutton = $this->output->action_link($url, get_string('recordvideo', 'block_opencast'),
-                        null, array('class' => 'btn btn-secondary', 'target' => '_blank'));
+                        null, array('class' => 'btn btn-secondary', 'target' => $target));
                     $html .= html_writer::div($recordvideobutton, 'opencast-recordvideo-wrap overview');
                 } else {
                     $recordvideo = new moodle_url('/blocks/opencast/recordvideo.php',
                         array('courseid' => $courseid, 'ocinstanceid' => $ocinstance->id));
                     $recordvideobutton = $this->output->action_link($recordvideo, get_string('recordvideo', 'block_opencast'),
-                        null, array('class' => 'btn btn-secondary', 'target' => '_blank'));
+                        null, array('class' => 'btn btn-secondary', 'target' => $target));
                     $html .= html_writer::div($recordvideobutton, 'opencast-recordvideo-wrap overview');
                 }
             }

--- a/settings.php
+++ b/settings.php
@@ -423,6 +423,12 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                     get_string('enableopencaststudiolink', 'block_opencast'),
                     get_string('enableopencaststudiolink_desc', 'block_opencast'), 0));
 
+            // New tab config for Studio.
+            $additionalsettings->add(
+                new admin_setting_configcheckbox('block_opencast/open_studio_in_new_tab_' . $instance->id,
+                    get_string('opencaststudionewtab', 'block_opencast'),
+                    get_string('opencaststudionewtab_desc', 'block_opencast'), 0));
+
             $additionalsettings->add(
                 new admin_setting_configtext('block_opencast/opencast_studio_baseurl_' . $instance->id,
                     get_string('opencaststudiobaseurl', 'block_opencast'),
@@ -437,6 +443,24 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                 new admin_setting_configpasswordunmask('block_opencast/lticonsumersecret_' . $instance->id,
                     get_string('lticonsumersecret', 'block_opencast'),
                     get_string('lticonsumersecret_desc', 'block_opencast'), ""));
+
+            // Studio redirect button settings.
+            $additionalsettings->add(
+                new admin_setting_configcheckbox('block_opencast/show_opencast_studio_return_btn_' . $instance->id,
+                    get_string('enableopencaststudioreturnbtn', 'block_opencast'),
+                    get_string('enableopencaststudioreturnbtn_desc', 'block_opencast'), 0));
+
+            $additionalsettings->add(
+                new admin_setting_configtext('block_opencast/opencast_studio_return_btn_label_' . $instance->id,
+                    get_string('opencaststudioreturnbtnlabel', 'block_opencast'),
+                    get_string('opencaststudioreturnbtnlabel_desc', 'block_opencast'),
+                    ''));
+
+            $additionalsettings->add(
+                new admin_setting_configtext('block_opencast/opencast_studio_return_url_' . $instance->id,
+                    get_string('opencaststudioreturnurl', 'block_opencast'),
+                    get_string('opencaststudioreturnurl_desc', 'block_opencast'),
+                    '/blocks/opencast/index.php?courseid=[COURSEID]&ocinstanceid=[OCINSTANCEID]'));
 
             // Opencast Editor Integration in additional feature settings.
             $additionalsettings->add(


### PR DESCRIPTION
With this PR, moodle will pass return params to Studio in order to provide the return button in Studio.
**Admin Settings**
- enable/disable new tab to redirect to studio.
- enable/disable passing return params feature.
- entering dynamic return button label in Studio.
- entering dynamic return url.

**How it work**
- Admin must enable this feature in config setting.
- It passes the url of the page where the request came from (where the Record Video Button is clicked), unless admin configures another URL (relative to wwwroot, capable to have 2 placeholders).
- It passes the site name as default button label, unless admin configures a custom label in the settings.
- Admin are now able to decide whether to use the same tab for Studio or open it on a new tab, by enabling this feature in setting!