### PR TITLE
metadata description with help icon, fixes #183

### DIFF
--- a/amd/src/block_settings.js
+++ b/amd/src/block_settings.js
@@ -40,6 +40,7 @@ export const init = (rolesinputid, metadatainputid, metadataseriesinputid, ocins
         {key: 'delete_confirm_metadata', component: 'block_opencast'},
         {key: 'heading_name', component: 'block_opencast'},
         {key: 'heading_datatype', component: 'block_opencast'},
+        {key: 'heading_description', component: 'block_opencast'},
         {key: 'heading_required', component: 'block_opencast'},
         {key: 'heading_readonly', component: 'block_opencast'},
         {key: 'heading_params', component: 'block_opencast'},
@@ -173,7 +174,14 @@ export const init = (rolesinputid, metadatainputid, metadataseriesinputid, ocins
                         }
                 },
                 {
-                    title: jsstrings[9],
+                    title: jsstrings[9] + '   ' + $('#helpbtndescription_' + ocinstanceid).html(),
+                    field: "description",
+                    editor: "textarea",
+                    widthGrow: 2,
+                    headerSort: false
+                },
+                {
+                    title: jsstrings[10],
                     field: "required", hozAlign: "center", widthGrow: 0, headerSort: false, formatter:
 
                         function (cell) {
@@ -188,7 +196,7 @@ export const init = (rolesinputid, metadatainputid, metadataseriesinputid, ocins
                         }
                 },
                 {
-                    title: jsstrings[10],
+                    title: jsstrings[11],
                     field: "readonly", hozAlign: "center", widthGrow: 0, headerSort: false, formatter:
                         function (cell) {
                             var input = document.createElement('input');
@@ -202,7 +210,7 @@ export const init = (rolesinputid, metadatainputid, metadataseriesinputid, ocins
                         }
                 },
                 {
-                    title: jsstrings[11] + '   ' + $('#helpbtnparams_' + ocinstanceid).html(),
+                    title: jsstrings[12] + '   ' + $('#helpbtnparams_' + ocinstanceid).html(),
                     field: "param_json",
                     editor: "textarea",
                     widthGrow: 2,
@@ -272,7 +280,14 @@ export const init = (rolesinputid, metadatainputid, metadataseriesinputid, ocins
                         }
                 },
                 {
-                    title: jsstrings[9],
+                    title: jsstrings[9] + '   ' + $('#helpbtndescription_' + ocinstanceid).html(),
+                    field: "description",
+                    editor: "textarea",
+                    widthGrow: 2,
+                    headerSort: false
+                },
+                {
+                    title: jsstrings[10],
                     field: "required", hozAlign: "center", widthGrow: 0, headerSort: false, formatter:
 
                         function (cell) {
@@ -287,7 +302,7 @@ export const init = (rolesinputid, metadatainputid, metadataseriesinputid, ocins
                         }
                 },
                 {
-                    title: jsstrings[10],
+                    title: jsstrings[11],
                     field: "readonly", hozAlign: "center", widthGrow: 0, headerSort: false, formatter:
                         function (cell) {
                             var input = document.createElement('input');
@@ -301,7 +316,7 @@ export const init = (rolesinputid, metadatainputid, metadataseriesinputid, ocins
                         }
                 },
                 {
-                    title: jsstrings[11] + '   ' + $('#helpbtnparams_' + ocinstanceid).html(),
+                    title: jsstrings[12] + '   ' + $('#helpbtnparams_' + ocinstanceid).html(),
                     field: "param_json",
                     editor: "textarea",
                     widthGrow: 2,

--- a/classes/local/addvideo_form.php
+++ b/classes/local/addvideo_form.php
@@ -48,7 +48,9 @@ class addvideo_form extends \moodleform
      * Form definition.
      */
     public function definition() {
-        global $CFG, $DB;
+        global $CFG, $DB, $PAGE;
+        // Get the renderer to use its methods.
+        $renderer = $PAGE->get_renderer('block_opencast');
         $ocinstanceid = $this->_customdata['ocinstanceid'];
 
         $usechunkupload = class_exists('\local_chunkupload\chunkupload_form_element')
@@ -126,8 +128,15 @@ class addvideo_form extends \moodleform
                 }
             }
 
-            $mform->addElement($field->datatype, $field->name, $this->try_get_string($field->name, 'block_opencast'),
+            // Get the created element back from addElement function, in order to further use its attrs.
+            $element = $mform->addElement($field->datatype, $field->name, $this->try_get_string($field->name, 'block_opencast'),
                 $param, $attributes);
+
+            // Check if the description is set for the field, to display it as help icon.
+            if (isset($field->description) && !empty($field->description)) {
+                // Use the renderer to generate a help icon with custom text.
+                $element->_helpbutton = $renderer->render_help_icon_with_custom_text($this->try_get_string($field->name, 'block_opencast'), $field->description);
+            }
 
             if ($field->datatype == 'text') {
                 $mform->setType($field->name, PARAM_TEXT);

--- a/classes/local/series_form.php
+++ b/classes/local/series_form.php
@@ -46,7 +46,9 @@ class series_form extends \moodleform
      * Form definition.
      */
     public function definition() {
-        global $USER;
+        global $USER, $PAGE;
+        // Get the renderer to use its methods.
+        $renderer = $PAGE->get_renderer('block_opencast');
         $mform = $this->_form;
 
         $ocinstanceid = $this->_customdata['ocinstanceid'];
@@ -88,9 +90,15 @@ class series_form extends \moodleform
             }
 
             $param['class'] = 'ignoredirty';
-
-            $mform->addElement($field->datatype, $field->name, $this->try_get_string($field->name, 'block_opencast'),
+            // Get the created element back from addElement function, in order to further use its attrs.
+            $element = $mform->addElement($field->datatype, $field->name, $this->try_get_string($field->name, 'block_opencast'),
                 $param, $attributes);
+
+            // Check if the description is set for the field, to display it as help icon.
+            if (isset($field->description) && !empty($field->description)) {
+                // Use the renderer to generate a help icon with custom text.
+                $element->_helpbutton = $renderer->render_help_icon_with_custom_text($this->try_get_string($field->name, 'block_opencast'), $field->description);
+            }
 
             if ($field->name == 'title') {
                 $mform->setDefault('title', $apibridge->get_default_seriestitle($this->_customdata['courseid'], $USER->id));

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -214,6 +214,8 @@ $string['catalogparam_help'] = '<b>JSON format:</b> {"param1":"value1", "param2"
 $string['contributor'] = 'Contributor(s)';
 $string['created'] = 'Created at';
 $string['creator'] = 'Presenter(s)';
+$string['descriptionmdfd'] = 'Field Description';
+$string['descriptionmdfd_help'] = 'The content of this field is presented as a help icon near the metadata field.';
 
 $string['date'] = 'Start Date';
 $string['descriptionmdfn'] = 'Field name';
@@ -327,6 +329,7 @@ $string['group_name_empty'] = 'The group name must not be empty if a group shoul
 
 $string['heading_name'] = 'Field Name';
 $string['heading_datatype'] = 'Field Type';
+$string['heading_description'] = 'Field Description';
 $string['heading_lti'] = 'Setting for LTI Configuration';$string['heading_position'] = 'Position';
 $string['heading_required'] = 'Required';
 $string['heading_readonly'] = 'Read Only';

--- a/renderer.php
+++ b/renderer.php
@@ -860,4 +860,24 @@ class block_opencast_renderer extends plugin_renderer_base
 
         return $this->render_from_template('block_opencast/series_table', $context);
     }
+
+    /**
+     * Renderes a help icon from core template, but with custom text to display.
+     *
+     * @param string $title The title to be displayed when hovering over the help icon.
+     * @param string $content The description text to be displayed when the help icon is clicked.
+     * @return string
+     */
+    public function render_help_icon_with_custom_text($title, $content) {
+        global $OUTPUT;
+        $context = new stdClass();
+        $context->title = get_string('helpprefix2', '', $title);
+        $context->alt = get_string('helpprefix2', '', $title);
+        $context->ltr = !right_to_left();
+
+        $context->text = format_text($content);
+
+        return $OUTPUT->render_from_template('core/help_icon', $context);
+
+    }
 }

--- a/settings.php
+++ b/settings.php
@@ -160,6 +160,8 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                 'helpbtnname_' . $instance->id, 'descriptionmdfn', 'block_opencast'));
             $generalsettings->add(new admin_setting_hiddenhelpbtn('block_opencast/hiddenhelpparams_' . $instance->id,
                 'helpbtnparams_' . $instance->id, 'catalogparam', 'block_opencast'));
+            $generalsettings->add(new admin_setting_hiddenhelpbtn('block_opencast/hiddenhelpdescription_' . $instance->id,
+                'helpbtndescription_' . $instance->id, 'descriptionmdfd', 'block_opencast'));
 
             $rolessetting = new admin_setting_configtext('block_opencast/roles_' . $instance->id,
                 get_string('aclrolesname', 'block_opencast'),


### PR DESCRIPTION
This PR fixes #183, which shows help icons in front of metadata fields to describe more about them.
**How it works**
- In admin setting page, under _Event Metadata_ and _Series Metadata_ section, the field tables now have another Column called "Field Description".
- If the above field in admin setting has a value, it adds a custom help icon in add forms.
- to render a help icon with custom text, a new method is introduced in `renderer.php` called `render_help_icon_with_custom_text`, which gets a title and content as text and pass them to the `core/help_icon` template to generate a custom help icon.