### PR TITLE
Prevent unwanted access from outside os courses

### DIFF
--- a/addvideo.php
+++ b/addvideo.php
@@ -33,12 +33,15 @@ $courseid = required_param('courseid', PARAM_INT);
 $series = optional_param('series', null, PARAM_ALPHANUMEXT);
 $ocinstanceid = optional_param('ocinstanceid', \tool_opencast\local\settings_api::get_default_ocinstance()->id, PARAM_INT);
 
+$baseurlparams = [
+    'ocinstanceid' => $ocinstanceid,
+    'courseid' => $courseid
+];
 if ($series) {
-    $baseurl = new moodle_url('/blocks/opencast/addvideo.php', array('courseid' => $courseid,
-        'ocinstanceid' => $ocinstanceid, 'series' => $series));
-} else {
-    $baseurl = new moodle_url('/blocks/opencast/addvideo.php', array('courseid' => $courseid, 'ocinstanceid' => $ocinstanceid));
+    $baseurlparams['series'] = $series;
 }
+$baseurl = new moodle_url('/blocks/opencast/addvideo.php', $baseurlparams);
+
 $PAGE->set_url($baseurl);
 
 if ($courseid == $SITE->id && $series) {
@@ -64,8 +67,7 @@ $PAGE->navbar->add(get_string('addvideo', 'block_opencast'), $baseurl);
 if ($courseid == $SITE->id) {
     // If upload initiated from overview page, check that capability is given in specific course or ownership.
     if (!$series) {
-        redirect(new moodle_url('/blocks/opencast/overview_videos.php', array('ocinstanceid' => $ocinstanceid,
-            'series' => $series)),
+        redirect(new moodle_url('/blocks/opencast/overview_videos.php', array('ocinstanceid' => $ocinstanceid, 'series' => null)),
             get_string('addvideonotallowed', 'block_opencast'), null,
             \core\output\notification::NOTIFY_ERROR);
     }

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -666,6 +666,10 @@ class apibridge {
      */
     public function get_series_by_identifier($seriesid, bool $withacl = false) {
 
+        if (empty($seriesid)) {
+            return null;
+        }
+
         $url = '/api/series/' . $seriesid;
 
         if ($withacl) {
@@ -770,7 +774,7 @@ class apibridge {
         global $SITE;
 
         // Skip course related placeholders if courseid is site id.
-        if ($courseid === $SITE->id) {
+        if (intval($courseid) === intval($SITE->id)) {
             if (strpos($name, '[COURSENAME]') !== false ||
                 strpos($name, '[COURSEID]') !== false ||
                 strpos($name, '[COURSEGROUPID]') !== false) {

--- a/index.php
+++ b/index.php
@@ -27,7 +27,7 @@ require_once($CFG->dirroot . '/lib/tablelib.php');
 use block_opencast\local\apibridge;
 use tool_opencast\local\settings_api;
 
-global $PAGE, $OUTPUT, $CFG, $DB, $USER;
+global $PAGE, $OUTPUT, $CFG, $DB, $USER, $SITE;
 
 $courseid = required_param('courseid', PARAM_INT);
 $ocinstanceid = optional_param('ocinstanceid', \tool_opencast\local\settings_api::get_default_ocinstance()->id, PARAM_INT);
@@ -197,7 +197,7 @@ if (has_capability('block/opencast:addvideo', $coursecontext)) {
 }
 
 // Section "Upload or record videos".
-if (has_capability('block/opencast:addvideo', $coursecontext)) {
+if (has_capability('block/opencast:addvideo', $coursecontext) && $SITE->id != $courseid) {
     // Show heading and explanation depending if Opencast Studio is enabled.
     if (get_config('block_opencast', 'enable_opencast_studio_link_' . $ocinstanceid)) {
         // Show heading.

--- a/renderer.php
+++ b/renderer.php
@@ -461,7 +461,7 @@ class block_opencast_renderer extends plugin_renderer_base {
      * @param bool $rendername
      */
     public function render_block_content($courseid, $videodata, $ocinstance, $rendername) {
-        global $USER;
+        global $USER, $SITE;
         $html = '';
 
         $coursecontext = context_course::instance($courseid);
@@ -470,7 +470,7 @@ class block_opencast_renderer extends plugin_renderer_base {
             $html .= $this->output->heading($ocinstance->name);
         }
 
-        if (has_capability('block/opencast:addvideo', $coursecontext)) {
+        if (has_capability('block/opencast:addvideo', $coursecontext)  && $SITE->id != $courseid) {
             $addvideourl = new moodle_url('/blocks/opencast/addvideo.php',
                 array('courseid' => $courseid, 'ocinstanceid' => $ocinstance->id));
             $addvideobutton = $this->output->single_button($addvideourl, get_string('addvideo', 'block_opencast'), 'get');
@@ -536,6 +536,11 @@ class block_opencast_renderer extends plugin_renderer_base {
             $moretext = get_string('morevideos', 'block_opencast');
         }
         $url = new moodle_url('/blocks/opencast/index.php', array('courseid' => $courseid, 'ocinstanceid' => $ocinstance->id));
+
+        // In admin page, we redirect to the series overview page to manage series from there.
+        if ($SITE->id == $courseid) {
+            $url = new moodle_url('/blocks/opencast/overview.php', array('ocinstanceid' => $ocinstance->id));
+        }
         $link = html_writer::link($url, $moretext);
         $html .= html_writer::div($link, 'opencast-more-wrap');
 


### PR DESCRIPTION
This PR fixes #293 and completes #294.

**How it works:**

- Prevent all functions that need series such as add video, record video add series, etc. in the admin page (outside courses).

- When the block is  added to adminpage, it redirects to series overview page to manage series from there, with required permissions and provided functions (including add video).
