### PR TITLE
Draft: fix for ingest upload

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -2843,7 +2843,7 @@ class apibridge {
     /**
      * Removes the stored file after the single upload is completed no matter what the status is.
      *
-     * @param \stored_file stored file object.
+     * @param \stored_file $storedfile stored file object.
      */
     public static function remove_single_stored_file($storedfile) {
         global $DB;

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -194,7 +194,7 @@ class apibridge {
             'mediaPackage' => $mediapackage,
             'flavor' => $flavor,
             'Body' => $file));
-        
+
         if ($file instanceof \stored_file) {
             $this->remove_single_stored_file($file);
         }

--- a/classes/local/ingest_uploader.php
+++ b/classes/local/ingest_uploader.php
@@ -82,11 +82,7 @@ class ingest_uploader {
                     upload_helper::ensure_series_metadata($job, $apibridge);
                     $episodexml = self::create_episode_xml($job);
 
-                    if (version_compare(phpversion(), '8', '>=')) {
-                        $file = new \CURLStringFile($episodexml, 'dublincore-episode.xml', 'text/xml');
-                    } else {
-                        $file = new PolyfillCURLStringFile($episodexml, 'dublincore-episode.xml', 'text/xml');
-                    }
+                    $file = $apibridge->get_xml_stored_file('dublincore-episode.xml', $episodexml);
 
                     $mediapackage = $apibridge->ingest_add_catalog($job->mediapackage, 'dublincore/episode', $file);
                     mtrace('... added episode metadata');
@@ -194,11 +190,7 @@ class ingest_uploader {
                     $initialvisibility = visibility_helper::get_initial_visibility($job);
                     $aclxml = self::create_acl_xml($initialvisibility->roles, $job);
 
-                    if (version_compare(phpversion(), '8', '>=')) {
-                        $file = new \CURLStringFile($aclxml, 'xacml-episode.xml', 'text/xml');
-                    } else {
-                        $file = new PolyfillCURLStringFile($aclxml, 'xacml-episode.xml', 'text/xml');
-                    }
+                    $file = $apibridge->get_xml_stored_file('xacml-episode.xml', $aclxml);
 
                     $mediapackage = $apibridge->ingest_add_attachment($job->mediapackage, 'security/xacml+episode', $file);
                     mtrace('... added acl');

--- a/classes/local/upload_helper.php
+++ b/classes/local/upload_helper.php
@@ -44,6 +44,9 @@ class upload_helper {
     /** @var string File area id where videos are uploaded */
     const OC_FILEAREA = 'videotoupload';
 
+    /** @var string File area id where xml file are uploaded */
+    const OC_XMLFILEAREA = 'xmlfiletoupload';
+
     /** @var int Video is ready to be uploaded */
     const STATUS_READY_TO_UPLOAD = 10;
 


### PR DESCRIPTION
This PR fixes the issue of ingest upload.

### Solution
The way that xml files are send during ingest upload was problematic because of using String Curl Files that did not match and did not suit, therefore, a new way of creating those xml files and storing them in moodle storage system is inroduced. Right after each file is used and has been send to the oc the actual file is deleted and the moodle file is also removed from DB, therefore, it leaves no track with the file records.

#### How to test this PR
In admin setting make sure you have enabled the ingest upload and saved changes.
Try to upload a video via add video page and make sure the uploadjob cron is running.
The result must be to successfully upload the video to opencast and no record of any file with `block_opencast` component and `xmlfiletoupload` filearea must be retrieavable in the files table of the moodle database.