### PR TITLE
lazy-load-settings for workflowselect

### DIFF
--- a/classes/admin_setting_workflowselect.php
+++ b/classes/admin_setting_workflowselect.php
@@ -1,0 +1,63 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+namespace block_opencast;
+
+defined('MOODLE_INTERNAL') || die();
+
+
+/**
+ * Admin settings class for workflow select.
+ *
+ * Just so we can lazy-load the choices.
+ *
+ * @copyright  2011 The Open University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class admin_setting_workflowselect extends \admin_setting_configselect{
+    protected $callopt=null;
+     /**
+     * Constructor.
+     *
+     * If you want to lazy-load the choices, pass a callback function that returns a choice
+     * array for the $choices parameter.
+     *
+     * @param string $name unique ascii name, either 'mysetting' for settings that in config, or 'myplugin/mysetting' for ones in config_plugins.
+     * @param string $visiblename localised
+     * @param string $description long localised info
+     * @param string|int $defaultsetting
+     * @param mixed $choices array of $value=>$label for each selection, or callback
+     */
+    public function __construct($name, $visiblename, $description, $defaultsetting, $choices,$callopt) {
+
+            $this->callopt = $callopt;
+        
+
+        parent::__construct($name, $visiblename, $description, $defaultsetting,$choices);
+    }
+
+    public function load_choices() {
+
+        if (is_array($this->choices)) {
+            return true;
+        }
+        
+        $this->choices = setting_helper::load_workflow_choices($this->callopt[0],$this->callopt[1]);
+
+        return true;
+    }
+}

--- a/classes/setting_helper.php
+++ b/classes/setting_helper.php
@@ -79,17 +79,23 @@ class setting_helper {
         if (during_initial_install()) {
             return null;
         }
-
+        global $SESSION;
         // Get the available workflows.
         $apibridge = \block_opencast\local\apibridge::get_instance($ocinstanceid);
+
 
         // Set workflows as choices. This is even done if there aren't any (real) workflows returned.
         try {
             return $apibridge->get_available_workflows_for_menu($workflowtag, true);
 
             // Something went wrong and the list of workflows could not be retrieved.
-        } catch (opencast_connection_exception | empty_configuration_exception $e) {
-            return $e;
+        } catch (opencast_connection_exception | empty_configuration_exception $e) {      
+            
+            if(!$SESSION->notifications){
+            $opencasterror = $e->getMessage();
+                \core\notification::error($opencasterror);
+            }
+            return [null => get_string('adminchoice_noconnection', 'block_opencast')];
         }
     }
 

--- a/settings.php
+++ b/settings.php
@@ -1037,10 +1037,6 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                     'block_opencast/importvideosmanualenabled_' . $instance->id, 'notchecked');
             }
 
-            // Don't spam other setting pages with error messages just because the tree was built.
-            if ($opencasterror && $PAGE->pagetype == 'admin-setting-block_opencast') {
-                \core\notification::error($opencasterror);
-            }
         }
     }
 }

--- a/settings.php
+++ b/settings.php
@@ -315,7 +315,7 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                     ''));
 
 
-            $generalsettings->add(new admin_setting_selectdelete('block_opencast/workflow_roles_' . $instance->id,
+            $generalsettings->add(new admin_setting_workflowselect('block_opencast/workflow_roles_' . $instance->id,
                     get_string('workflowrolesname', 'block_opencast'),
                     get_string('workflowrolesdesc', 'block_opencast'),
                     null, 'load_workflow_choices',array($instance->id,'archive'))
@@ -965,7 +965,7 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
             }
 
 
-            $select = new admin_setting_selectdelete('block_opencast/duplicateworkflow_' . $instance->id,
+            $select = new admin_setting_workflowselect('block_opencast/duplicateworkflow_' . $instance->id,
             get_string('duplicateworkflow', 'block_opencast'),
             get_string('duplicateworkflowdesc', 'block_opencast'),
             null, 'load_workflow_choices',array($instance->id,'api'));

--- a/settings.php
+++ b/settings.php
@@ -24,6 +24,7 @@
 
 use block_opencast\admin_setting_configeditabletable;
 use block_opencast\admin_setting_configtextvalidate;
+use block_opencast\admin_setting_workflowselect;
 use block_opencast\admin_setting_hiddenhelpbtn;
 use block_opencast\setting_helper;
 
@@ -219,18 +220,12 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                     get_string('limituploadjobs', 'block_opencast'),
                     get_string('limituploadjobsdesc', 'block_opencast', $link), 1, PARAM_INT));
 
-            $workflowchoices = setting_helper::load_workflow_choices($instance->id, 'upload');
-            if ($workflowchoices instanceof \block_opencast\opencast_connection_exception ||
-                $workflowchoices instanceof \tool_opencast\empty_configuration_exception) {
-                $opencasterror = $workflowchoices->getMessage();
-                $workflowchoices = [null => get_string('adminchoice_noconnection', 'block_opencast')];
-            }
+            $generalsettings-> add(new admin_setting_workflowselect('block_opencast/uploadworkflow_' . $instance->id,
+            get_string('uploadworkflow', 'block_opencast'),
+            get_string('uploadworkflowdesc', 'block_opencast'),
+            'ng-schedule-and-upload','load_workflow_choices',array($instance->id,'upload'))
+            );
 
-            $generalsettings->add(new admin_setting_configselect('block_opencast/uploadworkflow_' . $instance->id,
-                get_string('uploadworkflow', 'block_opencast'),
-                get_string('uploadworkflowdesc', 'block_opencast'),
-                'ng-schedule-and-upload', $workflowchoices
-            ));
 
             $generalsettings->add(new admin_setting_configcheckbox('block_opencast/publishtoengage_' . $instance->id,
                 get_string('publishtoengage', 'block_opencast'),
@@ -260,18 +255,12 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
             ));
 
 
-            $workflowchoices = setting_helper::load_workflow_choices($instance->id, 'delete');
-            if ($workflowchoices instanceof \block_opencast\opencast_connection_exception ||
-                $workflowchoices instanceof \tool_opencast\empty_configuration_exception) {
-                $opencasterror = $workflowchoices->getMessage();
-                $workflowchoices = [null => get_string('adminchoice_noconnection', 'block_opencast')];
-            }
+            $generalsettings->add(new admin_setting_workflowselect('block_opencast/deleteworkflow_' . $instance->id,
+            get_string('deleteworkflow', 'block_opencast'),
+            get_string('deleteworkflowdesc', 'block_opencast'),
+            null, 'load_workflow_choices',array($instance->id,'delete'))
+    );
 
-            $generalsettings->add(new admin_setting_configselect('block_opencast/deleteworkflow_' . $instance->id,
-                    get_string('deleteworkflow', 'block_opencast'),
-                    get_string('deleteworkflowdesc', 'block_opencast'),
-                    null, $workflowchoices)
-            );
 
             $generalsettings->add(new admin_setting_configcheckbox('block_opencast/adhocfiledeletion_' . $instance->id,
                 get_string('adhocfiledeletion', 'block_opencast'),
@@ -326,16 +315,10 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                     ''));
 
 
-            $workflowchoices = setting_helper::load_workflow_choices($instance->id, 'archive');
-            if ($workflowchoices instanceof \block_opencast\opencast_connection_exception ||
-                $workflowchoices instanceof \tool_opencast\empty_configuration_exception) {
-                $opencasterror = $workflowchoices->getMessage();
-                $workflowchoices = [null => get_string('adminchoice_noconnection', 'block_opencast')];
-            }
-            $generalsettings->add(new admin_setting_configselect('block_opencast/workflow_roles_' . $instance->id,
+            $generalsettings->add(new admin_setting_selectdelete('block_opencast/workflow_roles_' . $instance->id,
                     get_string('workflowrolesname', 'block_opencast'),
                     get_string('workflowrolesdesc', 'block_opencast'),
-                    null, $workflowchoices)
+                    null, 'load_workflow_choices',array($instance->id,'archive'))
             );
 
             $generalsettings->add($rolessetting);
@@ -981,17 +964,11 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                     'block_opencast/importvideosenabled_' . $instance->id, 'notchecked');
             }
 
-            // Import videos: Duplicate workflow.
-            $workflowchoices = setting_helper::load_workflow_choices($instance->id, 'api');
-            if ($workflowchoices instanceof \block_opencast\opencast_connection_exception ||
-                $workflowchoices instanceof \tool_opencast\empty_configuration_exception) {
-                $opencasterror = $workflowchoices->getMessage();
-                $workflowchoices = [null => get_string('adminchoice_noconnection', 'block_opencast')];
-            }
-            $select = new admin_setting_configselect('block_opencast/duplicateworkflow_' . $instance->id,
-                get_string('duplicateworkflow', 'block_opencast'),
-                get_string('duplicateworkflowdesc', 'block_opencast'),
-                null, $workflowchoices);
+
+            $select = new admin_setting_selectdelete('block_opencast/duplicateworkflow_' . $instance->id,
+            get_string('duplicateworkflow', 'block_opencast'),
+            get_string('duplicateworkflowdesc', 'block_opencast'),
+            null, 'load_workflow_choices',array($instance->id,'api'));
 
             if ($CFG->branch >= 310) { // The validation functionality for admin settings is not available before Moodle 3.10.
                 $select->set_validate_function([setting_helper::class, 'validate_workflow_setting']);


### PR DESCRIPTION
Hi, so i gave a try to implement lazy-loading to the workflow settings, preventing multiple call while navigating throught moodle admin settings. 
It works great on moodle 4.1.1.
Let me know if i can make it better.