### PR TITLE
Upgrade Transcription feature using event addTrack (OC 13)

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -12,3 +12,5 @@ jobs:
     with:
       requires-tool-plugin: true
       requires-mod-plugin: true
+      branch-tool-plugin: master
+      branch-mod-plugin: master

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -2917,4 +2917,44 @@ class apibridge {
         }
         return true;
     }
+
+    /**
+     * The allowance of providing download video button
+     * @param object $video Opencast video
+     * @param int $courseid Course id
+     * @param bool $capabilitycheck
+     * @return bool whether to provide the download button
+     */
+    public function can_show_download_button($video, $courseid, $capabilitycheck = true) {
+        // Only when the video processing is SUCCEEDED, to avoid any misunderstanding.
+        if ($video->is_downloadable && isset($video->processing_state) && $video->processing_state == "SUCCEEDED") {
+            if ($capabilitycheck) {
+                $coursecontext = \context_course::instance($courseid);
+                return has_capability('block/opencast:downloadvideo', $coursecontext);
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The allowance of providing direct access link button
+     * @param object $video Opencast video
+     * @param int $courseid Course id
+     * @param bool $capabilitycheck
+     * @return bool whether to provide the download button
+     */
+    public function can_show_directaccess_link($video, $courseid, $capabilitycheck = true) {
+        // Only when the video processing is SUCCEEDED, to avoid any misunderstanding.
+        if ($video->is_accessible && isset($video->processing_state) && $video->processing_state == "SUCCEEDED") {
+            if ($capabilitycheck) {
+                $coursecontext = \context_course::instance($courseid);
+                return has_capability('block/opencast:sharedirectaccessvideolink', $coursecontext);
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -508,9 +508,11 @@ class apibridge {
      * @param string $identifier Event id
      * @param bool $withpublications If true, publications are included
      * @param bool $withacl If true, ACLs are included
+     * @param bool $includingmedia If true, media files are included
      * @return \stdClass Video
      */
-    public function get_opencast_video($identifier, bool $withpublications = false, bool $withacl = false) {
+    public function get_opencast_video($identifier, bool $withpublications = false, bool $withacl = false,
+                                        bool $includingmedia = false) {
         $result = new \stdClass();
         $result->video = false;
         $result->error = 0;
@@ -538,6 +540,16 @@ class apibridge {
         $this->extend_video_status($video);
         $this->set_download_state($video);
         $this->set_access_state($video);
+        // Including media into the video object.
+        if ($includingmedia) {
+            $media = null;
+            $response = $this->api->opencastapi->eventsApi->getMedia($identifier);
+            $code = $response['code'];
+            if ($code === 200) {
+                $media = $response['body'];
+            }
+            $video->media = $media;
+        }
 
         $result->video = $video;
 
@@ -1239,7 +1251,7 @@ class apibridge {
     public function get_upload_filestream($file, $type = 'video') {
         $tempdirname = "oc{$type}toupload";
         $tempdir = make_temp_directory($tempdirname);
-        $tempfilepath = tempnam($tempdir, 'tempup_') . $file->get_filename();
+        $tempfilepath = tempnam($tempdir, 'block_opencast_' . $type . '_upload') . '_' . $file->get_filename();
         $filestream = null;
         if ($file instanceof \stored_file) {
             if ($file->copy_content_to($tempfilepath)) {
@@ -2864,5 +2876,45 @@ class apibridge {
         }
 
         return \block_opencast\task\process_duplicated_event_visibility_change::TASK_FAILED;
+    }
+
+    /**
+     * Get the opencast version.
+     *
+     * @return string semantic version number of the opencast server.
+     */
+    public function get_opencast_version() {
+        $response = $this->api->opencastapi->sysinfo->getVersion();
+        $code = $response['code'];
+        $versionobject = $response['body'];
+        if ($code === 0) {
+            throw new opencast_connection_exception('connection_failure', 'block_opencast');
+        } else if ($code != 200) {
+            throw new opencast_connection_exception('unexpected_api_response', 'block_opencast');
+        }
+        return $versionobject->version;
+    }
+
+    /**
+     * Adds tracks into opencast event.
+     * This endpoint has been introduced in Opencast 13, it is recommended to check the opencast version before using this method.
+     *
+     * @param string $identifier event identifier.
+     * @param string $flavor the track flavor.
+     * @param object $file the track filestream object.
+     * @param boolean $overwrite whether to overwrite the existing one.
+     *
+     * @return boolean true, if the track is added.
+     * @throws opencast_connection_exception
+     */
+    public function event_add_track($identifier, $flavor, $file, $overwrite = true) {
+        $response = $this->api->opencastapi->eventsApi->addTrack($identifier, $flavor, $file, $overwrite);
+        $code = $response['code'];
+        if ($code === 0) {
+            throw new opencast_connection_exception('connection_failure', 'block_opencast');
+        } else if ($code != 200) {
+            throw new opencast_connection_exception('unexpected_api_response', 'block_opencast');
+        }
+        return true;
     }
 }

--- a/index.php
+++ b/index.php
@@ -463,11 +463,11 @@ foreach ($seriesvideodata as $series => $videodata) {
                 $actions .= $renderer->render_edit_functions($ocinstanceid, $courseid, $video->identifier, $updatemetadata,
                     $workflowsavailable, $coursecontext, $useeditor, $canchangeowner, $canmanagetranscriptions);
 
-                if (has_capability('block/opencast:downloadvideo', $coursecontext) && $video->is_downloadable) {
+                if ($opencast->can_show_download_button($video, $courseid)) {
                     $actions .= $renderer->render_download_event_icon($ocinstanceid, $courseid, $video);
                 }
 
-                if (has_capability('block/opencast:sharedirectaccessvideolink', $coursecontext) && $video->is_accessible) {
+                if ($opencast->can_show_directaccess_link($video, $courseid)) {
                     $actions .= $renderer->render_direct_link_event_icon($ocinstanceid, $courseid, $video);
                 }
 

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -778,9 +778,9 @@ $string['transcriptionsettingsheader'] = 'Settings for Transcription';
 $string['transcriptionworkflow'] = 'Workflow for transcription (speech to text)';
 $string['transcriptionworkflow_desc'] = 'This workflow is triggered when transcription files are attached to the video. If not set, uploading and managing transcriptions is not provided.<br>By setting this workflow, a new section to upload transcription files in the add video page as well as a new action menu item in overview page is provided, to upload/handle the new/current transcriptions files.';
 $string['deletetranscriptionworkflow'] = 'Workflow for delete transcription';
-$string['ltidownloadtranscription'] = 'Download transcription with LTI';
-$string['ltidownloadtranscription_desc'] = 'When enabled, the transcription download button will redirect users to a new page and performs an LTI authentification by which the users will the get the content of the transcription file.<br>
-    NOTE: This configuration is meant to be used for those opencast systems that have Secure Static Files enabled.';
+$string['allowdownloadtranscriptionsetting'] = 'Allow download transcriptions';
+$string['allowdownloadtranscriptionsetting_desc'] = 'When enabled, the transcription download button will be displayed in the manage transcriptions page, by which teachers are able to download the transcription\'s file.<br>
+    <b>Notice:</b> In case you are using Opencast 13 or later, you need to make sure that all prerequisites including LTI features and permissions to access /assets/ endpoint for LTI users, are set correctly as it is mandatory to perform LTI call.';
 $string['transcription_flavor_key'] = 'Flavor key';
 $string['transcription_flavor_value'] = 'Flavor value';
 $string['transcription_flavor_delete'] = 'Delete flavor\'s option pair';
@@ -824,8 +824,9 @@ $string['unabletodeletetranscription'] = 'Unable to delete transcription';
 $string['transcriptiondeletionsucceeded'] = 'Transcription deleted successfully.';
 $string['transcriptiondeletionfailed'] = 'Failed to delete transcription';
 $string['deletetranscription_desc'] = 'You are about to delete the transcription.<br>Are you sure you would like to delete it?';
-$string['downloadtranscription'] = 'Download transcription';
 $string['unabletodownloadtranscription'] = 'Unable to download transcription';
+$string['transcriptionltidownloadcompleted'] = 'The transcription is successfully downloaded. {$a}';
+$string['transcriptionreturntomanagement'] = 'Go back to transcription management page';
 // Strings for live update feature.
 $string['liveupdate_settingheader'] = 'Live Status Update';
 $string['liveupdate_settingenabled'] = 'Enable live status update feature';

--- a/renderer.php
+++ b/renderer.php
@@ -1402,23 +1402,23 @@ class block_opencast_renderer extends plugin_renderer_base {
                 $subobj->flavor = !empty($flavorname) ?
                     $flavorname :
                     get_string('notranscriptionflavor', 'block_opencast', $flavortype);
-        
+
                 // Extracting id and type from attributes.
                 $subobj->id = $subobj->{'@attributes'}->id;
                 $subobj->type = $type;
-        
+
                 // Preparing delete url.
                 $deleteurl = new moodle_url('/blocks/opencast/deletetranscription.php',
                 array('courseid' => $courseid, 'ocinstanceid' => $ocinstanceid,
                     'video_identifier' => $identifier, 'transcription_identifier' => $subobj->id));
                 $subobj->deleteurl = $deleteurl->out(false);
-        
+
                 // Preparing download url.
                 $downloadurl = new moodle_url('/blocks/opencast/downloadtranscription.php',
                 array('courseid' => $courseid, 'ocinstanceid' => $ocinstanceid, 'domain' => $domain,
                     'video_identifier' => $identifier, 'attachment_type' => str_replace(['/', '+'], ['-', '_'], $type)));
                 $subobj->downloadurl = $downloadurl->out(false);
-        
+
                 $items[] = $subobj;
             }
         }

--- a/renderer.php
+++ b/renderer.php
@@ -431,11 +431,11 @@ class block_opencast_renderer extends plugin_renderer_base {
                     false, null, false, false, false, 'overview', $video->is_part_of);
             }
 
-            if ($hasdownloadpermission && $video->is_downloadable) {
+            if ($hasdownloadpermission && $apibridge->can_show_download_button($video, $SITE->id, false)) {
                 $actions .= $this->render_download_event_icon($ocinstanceid, $SITE->id, $video);
             }
 
-            if ($hasaccesspermission && $video->is_accessible) {
+            if ($hasaccesspermission && $apibridge->can_show_directaccess_link($video, $SITE->id, false)) {
                 $actions .= $this->render_direct_link_event_icon($ocinstanceid, $SITE->id, $video);
             }
 
@@ -1215,7 +1215,9 @@ class block_opencast_renderer extends plugin_renderer_base {
         foreach ($video->publications as $publication) {
             if ($publication->channel == get_config('block_opencast', 'download_channel_' . $ocinstanceid)) {
                 foreach ($publication->media as $media) {
-                    $name = ucwords(explode('/', $media->flavor)[0]) . ' (' . $media->width . 'x' . $media->height . ')';
+                    $width = property_exists($media, 'width') ? $media->width : 0;
+                    $height = property_exists($media, 'height') ? $media->height : 0;
+                    $name = ucwords(explode('/', $media->flavor)[0]) . ' (' . $width . 'x' . $height . ')';
                     $actionmenu->add(new action_menu_link_secondary(
                         new \moodle_url('/blocks/opencast/downloadvideo.php',
                             array('video_identifier' => $video->identifier, 'courseid' => $courseid,
@@ -1258,7 +1260,9 @@ class block_opencast_renderer extends plugin_renderer_base {
         foreach ($video->publications as $publication) {
             if ($publication->channel == get_config('block_opencast', 'direct_access_channel_' . $ocinstanceid)) {
                 foreach ($publication->media as $media) {
-                    $name = ucwords(explode('/', $media->flavor)[0]) . ' (' . $media->width . 'x' . $media->height . ')';
+                    $width = property_exists($media, 'width') ? $media->width : 0;
+                    $height = property_exists($media, 'height') ? $media->height : 0;
+                    $name = ucwords(explode('/', $media->flavor)[0]) . ' (' . $width . 'x' . $height . ')';
                     $url = new \moodle_url('/blocks/opencast/directaccess.php',
                         array('video_identifier' => $video->identifier, 'courseid' => $courseid,
                             'mediaid' => $media->id, 'ocinstanceid' => $ocinstanceid));

--- a/settings.php
+++ b/settings.php
@@ -664,10 +664,10 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                 'block_opencast/transcriptionworkflow_' . $instance->id, 'eq', '');
 
             $additionalsettings->add(
-                new admin_setting_configcheckbox('block_opencast/ltidownloadtranscription_' . $instance->id,
-                    get_string('ltidownloadtranscription', 'block_opencast'),
-                    get_string('ltidownloadtranscription_desc', 'block_opencast'), 0));
-            $additionalsettings->hide_if('block_opencast/ltidownloadtranscription_' . $instance->id,
+                new admin_setting_configcheckbox('block_opencast/allowdownloadtranscription_' . $instance->id,
+                    get_string('allowdownloadtranscriptionsetting', 'block_opencast'),
+                    get_string('allowdownloadtranscriptionsetting_desc', 'block_opencast'), 1));
+            $additionalsettings->hide_if('block_opencast/allowdownloadtranscription_' . $instance->id,
                 'block_opencast/transcriptionworkflow_' . $instance->id, 'eq', '');
 
             $additionalsettings->add($transcriptionflavors);

--- a/templates/transcriptions_table.mustache
+++ b/templates/transcriptions_table.mustache
@@ -33,9 +33,11 @@
                     <th>
                         {{# str}}transcriptionflavor_thead, block_opencast {{/ str}}
                     </th>
-                    <th>
-                        {{# str}}transcriptionaction_thead, block_opencast {{/ str}}
-                    </th>
+                    {{#hasactions}}
+                        <th>
+                            {{# str}}transcriptionaction_thead, block_opencast {{/ str}}
+                        </th>
+                    {{/hasactions}}
                 </tr>
             </thead>
             <tbody>
@@ -44,16 +46,20 @@
                         <td>
                             {{flavor}}
                         </td>
-                        <td width="10%">
-                            <a class="iconsmall" {{#downloadblanktarget}}target="_blank"{{/downloadblanktarget}} title="{{#str}} downloadtranscription, block_opencast {{/str}}" href="{{downloadurl}}">
-                                {{#pix}} i/down, core{{/pix}}
-                            </a>
-                            {{#candelete}}
-                                <a class="iconsmall" title="{{#str}} deletetranscription, block_opencast {{/str}}" href="{{deleteurl}}">
-                                    {{#pix}} i/delete, core{{/pix}}
-                                </a>
-                            {{/candelete}}
-                        </td>
+                        {{#hasactions}}
+                            <td width="10%">
+                                {{#allowdownload}}
+                                    <a class="iconsmall" target="_blank" title="{{#str}} downloadtranscription, block_opencast {{/str}}" href="{{downloadurl}}">
+                                        {{#pix}} i/down, core{{/pix}}
+                                    </a>
+                                {{/allowdownload}}
+                                {{#candelete}}
+                                    <a class="iconsmall" title="{{#str}} deletetranscription, block_opencast {{/str}}" href="{{deleteurl}}">
+                                        {{#pix}} i/delete, core{{/pix}}
+                                    </a>
+                                {{/candelete}}
+                            </td>
+                        {{/hasactions}}
                     </tr>
                 {{/list}}
             </tbody>

--- a/tests/behat/behat_block_opencast.php
+++ b/tests/behat/behat_block_opencast.php
@@ -139,7 +139,7 @@ class behat_block_opencast extends behat_base {
      * @Given /^I go to direct access link$/
      */
     public function i_go_to_direct_access_link() {
-        // get the direct access link.
+        // Get the direct access link.
         if (empty($this->directaccesslink)) {
             $csselement = '#opencast-videos-table-ID-blender-foundation_r0 .c3 .access-action-menu a.access-link-copytoclipboard';
             try {

--- a/tests/behat/block_opencast_directaccess.feature
+++ b/tests/behat/block_opencast_directaccess.feature
@@ -31,6 +31,7 @@ Feature: Direct Access via shared link
       | enablechunkupload_1     | 0                                                             | block_opencast |
       | workflow_roles_1        | republish-metadata                                            | block_opencast |
       | direct_access_channel_1 | engage-player                                                 | block_opencast |
+      | liveupdateenabled_1     | 0                                                             | block_opencast |
     And I log in as "admin"
     And I am on "Course 1" course homepage with editing mode on
     And I add the "Opencast Videos" block
@@ -42,6 +43,8 @@ Feature: Direct Access via shared link
     And I wait "2" seconds
     And I click on "Opencast Videos" "link"
     And I wait until no video is being processed
+    And I wait "1" seconds
+    And I reload the page
     And I log out
 
   @javascript

--- a/tests/helper/apibridge_testable.php
+++ b/tests/helper/apibridge_testable.php
@@ -143,9 +143,11 @@ class block_opencast_apibridge_testable extends \block_opencast\local\apibridge 
      * @param string $identifier Event id
      * @param bool $withpublications If true, publications are included
      * @param bool $withacl If true, ACLs are included
+     * @param bool $includingmedia If true, media files are included
      * @return \stdClass Video
      */
-    public function get_opencast_video($identifier, bool $withpublications = false, bool $withacl = false) {
+    public function get_opencast_video($identifier, bool $withpublications = false, bool $withacl = false,
+                                        bool $includingmedia = false) {
         $result = new \stdClass();
         $result->video = false;
         $result->error = 0;

--- a/tests/upload_test.php
+++ b/tests/upload_test.php
@@ -40,14 +40,11 @@ global $CFG;
 class upload_test extends advanced_testcase {
 
     /** @var string Test api url. */
-    // private $apiurl = 'http://127.0.0.1:8080';
-    private $apiurl = 'https://moodle-opencast.opencast-niedersachsen.de';
+    private $apiurl = 'http://127.0.0.1:8080';
     /** @var string Test api username. */
-    // private $apiusername = 'admin';
-    private $apiusername = 'moodle';
+    private $apiusername = 'admin';
     /** @var string Test api password. */
-    // private $apipassword = 'opencast';
-    private $apipassword = '6dwt5qbuXEBkvsu';
+    private $apipassword = 'opencast';
     /** @var int the curl timeout in milliseconds */
     private $apitimeout = 2000;
     /** @var int the curl connecttimeout in milliseconds */

--- a/tests/upload_test.php
+++ b/tests/upload_test.php
@@ -151,7 +151,7 @@ class upload_test extends advanced_testcase {
      *
      * @return bool true if the video is avialable, false otherwise.
      */
-    private function notest_check_uploaded_video($courseid, \block_opencast\local\apibridge $apibridge) {
+    private function notest_check_uploaded_video($courseid, $apibridge) {
         $uploadhelper = new \block_opencast\local\upload_helper();
         // Prevent mtrace output, which would be considered risky.
         ob_start();

--- a/tests/upload_test.php
+++ b/tests/upload_test.php
@@ -147,7 +147,7 @@ class upload_test extends advanced_testcase {
      * Checks, if the video is available after upload, by running cron first to make sure upload video took place successfully.
      *
      * @param int $courseid Course ID
-     * @param \block_opencast\local\apibridge the apibridge instance
+     * @param \block_opencast\local\apibridge $apibridge the apibridge instance
      *
      * @return bool true if the video is avialable, false otherwise.
      */


### PR DESCRIPTION
This PR is meant to contain the upgrade and requirements to use the latest opencast 13 features (event addTrack).
### Prerequisites
- As for downloading the transcription files from media, you need to have LTI feature enabled [(Configure LTI)](https://docs.opencast.org/r/13.x/admin/#modules/ltimodule/#configure-lti)
- Make sure that LTI users can access 'assets/**' endpoint: 
-- In `/etc/opencast/security/mh_default_org.xml` add `ROLE OAUTH_USER` to the access of `/assets/assets/**` or provide your own more secure pattern.
![Screenshot 2023-05-22 at 17 46 25](https://github.com/Opencast-Moodle/moodle-block_opencast/assets/53179227/1ae47171-4d59-4b79-b5cc-db1cc9d92b75)


### How it works:
- It checks the opencast version and if 13 and later is detected, switches to addTrack using media to upload transcriptions.
- It still supports the old approach, which makes it easier to handle everything.
- As it is mandatory to perform LTI call to access the file, all download requests are now via LTI call.
- The setting to download via LTI is removed.
- A new setting to allow download is introduced.

### How to test this PR:
- Setting for transcriptions must be set correctly.
- Try to upload video with transcriptions.
- Make sure cron is running every minute.
- In overview page, via Manage transcription action menu item, you could see the list of existing/add new/download or delete transcriptions.
- Perform all mentioned features via the transcription management page.
- Make sure LTI feature is enabled.