### PR TITLE
New query param to be appended into Studio url path

### DIFF
--- a/index.php
+++ b/index.php
@@ -255,7 +255,9 @@ if (has_capability('block/opencast:addvideo', $coursecontext) && $SITE->id != $c
                 $endpoint = 'http://' . $endpoint;
             }
 
-            $url = $endpoint . '/studio?upload.seriesId=' . $apibridge->get_stored_seriesid($courseid, true, $USER->id);
+            $seriesid = $apibridge->get_stored_seriesid($courseid, true, $USER->id);
+            $studiourlpath = $apibridge->generate_studio_url_path($courseid, $seriesid);
+            $url = $endpoint . $studiourlpath;
             $recordvideobutton = $OUTPUT->action_link($url, get_string('recordvideo', 'block_opencast'),
                 null, array('class' => 'btn btn-secondary', 'target' => $target));
             echo html_writer::div($recordvideobutton, 'opencast-recordvideo-wrap');

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -726,6 +726,8 @@ $string['opencaststudioreturnurl'] = 'Custom Studio return endpoint URL';
 $string['opencaststudioreturnurl_desc'] = 'When empty the return url redirects back to the same Moodle opencast block overview where the request comes from. A custom endpoint URL will then be passed to Studio as return url when configured, in this case, admin is able to use 2 placeholders including [OCINSTANCEID] and [COURSEID]. Please NOTE: the URL must be relative to wwwroot.';
 $string['opencaststudioreturnbtnlabel'] = 'Label for Studio\'s return button';
 $string['opencaststudioreturnbtnlabel_desc'] = 'This label works as a short description where the return link leads to. This label will be appended to the Studio return button text, when empty, moodle site name will be passed as label.';
+$string['opencaststudiocustomsettingsfilename'] = 'Custom Studio settings filename';
+$string['opencaststudiocustomsettingsfilename_desc'] = 'This custom settings filename will be appended to the query when redirecting to Studio, afterwards the Studio looks for this filename relative to its directory and read its settings from that file.<br><b>NOTE</b>: Requires Opencast 14.2 or later.';
 
 // Strings for new visibility feature during initail upload.
 $string['visibilityheader'] = 'Event Visibility';

--- a/renderer.php
+++ b/renderer.php
@@ -500,8 +500,9 @@ class block_opencast_renderer extends plugin_renderer_base {
                     if (strpos($endpoint, 'http') !== 0) {
                         $endpoint = 'http://' . $endpoint;
                     }
-
-                    $url = $endpoint . '/studio?upload.seriesId=' . $apibridge->get_stored_seriesid($courseid, true, $USER->id);
+                    $seriesid = $apibridge->get_stored_seriesid($courseid, true, $USER->id);
+                    $studiourlpath = $apibridge->generate_studio_url_path($courseid, $seriesid);
+                    $url = $endpoint . $studiourlpath;
                     $recordvideobutton = $this->output->action_link($url, get_string('recordvideo', 'block_opencast'),
                         null, array('class' => 'btn btn-secondary', 'target' => $target));
                     $html .= html_writer::div($recordvideobutton, 'opencast-recordvideo-wrap overview');

--- a/settings.php
+++ b/settings.php
@@ -446,6 +446,12 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
                     get_string('opencaststudioreturnurl_desc', 'block_opencast'),
                     '/blocks/opencast/index.php?courseid=[COURSEID]&ocinstanceid=[OCINSTANCEID]'));
 
+            $additionalsettings->add(
+                new admin_setting_configtext('block_opencast/opencast_studio_custom_settings_filename_' . $instance->id,
+                    get_string('opencaststudiocustomsettingsfilename', 'block_opencast'),
+                    get_string('opencaststudiocustomsettingsfilename_desc', 'block_opencast'),
+                    ''));
+
             // Opencast Editor Integration in additional feature settings.
             $additionalsettings->add(
                 new admin_setting_heading('block_opencast/opencast_videoeditor_' . $instance->id,


### PR DESCRIPTION
This PR fixes #337 

### How it works
- a new method is introduced in `apibridge` class called `generate_studio_url_path` to have a central place responsible for that.
- a new setting called `opencast_studio_custom_settings_filename` is provided in admin setting to enter the custom setting FILENAME for the studio.
- In case of redirect to studio without lti call, the label and return url + setting filename is now also appended to the studio url path.

### To test this PR:
You would need:
- latest version of tool_opencast master branch.
- the changes in Opencast side will be in place and functional only in Opencast v14.2
- After installing this PR make sure you purge the caches for everything especially texts to work properly.


**NOTE**: As of writing this PR, it is not yet tested and finalized, therefore upcoming updates and improvements will be expected. Keep track of the commits adding to this PR!
