### PR TITLE
Remove unnecessary query parameter

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -301,7 +301,7 @@ class apibridge {
      * @param bool $withmetadata
      * @return \stdClass
      */
-    public function get_block_videos($courseid, $withmetadata = true) {
+    public function get_block_videos($courseid, $withmetadata = false) {
 
         $result = new \stdClass();
         $result->count = 0;
@@ -407,7 +407,7 @@ class apibridge {
      * @param bool $withmetadata
      * @return array
      */
-    public function get_series_videos($series, $sortcolumns = null, $withmetadata = true) {
+    public function get_series_videos($series, $sortcolumns = null, $withmetadata = false) {
 
         $result = new \stdClass();
         $result->videos = array();


### PR DESCRIPTION
The `withmetadata=true` query parameter is a heavy operation and is pretty slow on receiving multiple events. The result is not used, so we can safely remove that parameter.

We use that patch currently in production, and we found no problems during testing. However, we are only using a subset of the features.