### PR TITLE
PHP 7 backward compatibility

### DIFF
--- a/block_opencast.php
+++ b/block_opencast.php
@@ -214,7 +214,8 @@ class block_opencast extends block_base {
 
             // We filter the controls to find the delete action link.
             $deleteactionfiltered = array_filter($bc->controls, function ($actionlink) {
-                return str_contains($actionlink->attributes['class'], 'editing_delete');
+                // Using strpos in order to make the plugin PHP 7 backward compatible.
+                return strpos($actionlink->attributes['class'], 'editing_delete') !== false;
             });
 
             // In case the delete action link could be found, we try to replace its properties.
@@ -225,7 +226,8 @@ class block_opencast extends block_base {
                 // Delete all modal-related attributes.
                 if (isset($deleteaction->attributes)) {
                     foreach ($deleteaction->attributes as $k => $v) {
-                        if (str_starts_with($k, 'data-modal')) {
+                        // Using substr in order to make the plugin PHP 7 backward compatible.
+                        if (substr($k, 0, 10) === 'data-modal') {
                             unset($deleteaction->attributes[$k]);
                         }
                     }


### PR DESCRIPTION
This PR fixes #359,

### Description
The plugin still offers support for PHP 7.x, therefore using pure PHP 8 functions ends up in fatal errors when using PHP 7 on your installation. The goal of this PR is to replace those functions with more compatible ones.