### PR TITLE
Hidden duplicated videos end up having empty ACLs

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -1573,12 +1573,13 @@ class apibridge {
      * @param int $courseid id of the course the event belongs to.
      * @param int $visibility visibility of the event.
      * @param array|null $groups array of group ids used for replacing the placeholders
+     * @param bool $forceonhidden flag to force return the acls when hidden.
      * @return array of objects representing acl rules, each with the fields 'allow', 'action' and 'role'.
      * @throws dml_exception
      * @throws coding_exception In case of an invalid visibility status. Only [0,1,2] are allowed.
      */
-    private function get_permanent_acl_rules_for_status($courseid, $visibility, $groups = null) {
-        return $this->get_acl_rules_for_status($courseid, $visibility, true, $groups);
+    private function get_permanent_acl_rules_for_status($courseid, $visibility, $groups = null, $forceonhidden = false) {
+        return $this->get_acl_rules_for_status($courseid, $visibility, true, $groups, $forceonhidden);
     }
 
     /**
@@ -1588,11 +1589,12 @@ class apibridge {
      * @param int $visibility visibility of the event.
      * @param bool $permanent whether to get permanent or non-permanent acl rules.
      * @param array|null $groups array of group ids used for replacing the placeholders
+     * @param bool $forceonhidden flag to force return the acls when hidden.
      * @return array of objects representing acl rules, each with the fields 'allow', 'action' and 'role'.
      * @throws dml_exception
      * @throws coding_exception In case of an invalid visibility status. Only [0,1,2] are allowed.
      */
-    private function get_acl_rules_for_status($courseid, $visibility, $permanent, $groups = null) {
+    private function get_acl_rules_for_status($courseid, $visibility, $permanent, $groups = null, $forceonhidden = false) {
         $roles = $this->getroles($permanent ? 1 : 0);
 
         $result = [];
@@ -1614,6 +1616,21 @@ class apibridge {
                 }
                 break;
             case block_opencast_renderer::HIDDEN:
+                if ($permanent && $forceonhidden) {
+                    foreach ($roles as $role) {
+                        foreach ($role->actions as $action) {
+                            $rolenameformatted = self::replace_placeholders($role->rolename, $courseid)[0];
+                            // Might return null if USERNAME cannot be replaced.
+                            if ($rolenameformatted) {
+                                $result[] = (object)[
+                                    'allow' => true,
+                                    'action' => $action,
+                                    'role' => $rolenameformatted,
+                                ];
+                            }
+                        }
+                    }
+                }
                 break;
             case block_opencast_renderer::GROUP:
                 foreach ($roles as $role) {
@@ -2881,7 +2898,7 @@ class apibridge {
         $event = new event();
         // Gathering acls for the duplicated event.
         $newacls = $this->get_non_permanent_acl_rules_for_status($courseid, $targetvisibiltiy, $groups);
-        $newacls = array_merge($newacls, $this->get_permanent_acl_rules_for_status($courseid, $targetvisibiltiy, $groups));
+        $newacls = array_merge($newacls, $this->get_permanent_acl_rules_for_status($courseid, $targetvisibiltiy, $groups, true));
         foreach ($newacls as $acl) {
             $event->add_acl($acl->allow, $acl->action, $acl->role);
         }

--- a/classes/task/process_duplicated_event_visibility_change.php
+++ b/classes/task/process_duplicated_event_visibility_change.php
@@ -113,7 +113,7 @@ class process_duplicated_event_visibility_change extends adhoc_task {
             $event = $apibridge->get_already_existing_event([$data->duplicatedeventid]);
             if (!$event || !in_array($event->status, ['EVENTS.EVENTS.STATUS.PROCESSED', 'EVENTS.EVENTS.STATUS.PROCESSING_FAILURE'])
                 || count($event->publication_status) == 0
-                || count($event->publication_status) == 1 && $event->publication_status[0] === 'internal') {
+                || (count($event->publication_status) == 1 && $event->publication_status[0] === 'internal')) {
                 throw new moodle_exception('error_duplicated_event_id_not_ready', 'block_opencast', '', $a);
             }
 


### PR DESCRIPTION
This PR fixes #371 

### Description
Please refer to the issue's description and comments. https://github.com/Opencast-Moodle/moodle-block_opencast/issues/371#issuecomment-2020047954

### Solution
- Added a new argument to the methods: `get_permanent_acl_rules_for_status` and `get_acl_rules_for_status` called `$forceonhidden` which is a flag to return the permanent roles even if the visibility is hidden.
   - The reason to add new argument is to maintain the original concept and to not touch any old behavior.
- if that flag is true then in `get_acl_rules_for_status` in case of hidden we check first if it is permanent and it is forced to return roles, then we prepare the roles and pass it back as the result.

### How to TEST this PR.
- Make sure you are using duplicate event mode for import videos.
- Try to import a mixture of hidden and visible videos in a course to a new one, either by Manual import or Course (bulk) Import wizard.
- Make sure the cronjob is working.
- You would need to wait for both `process_duplicate_event` and ultimately `process_duplicated_event_visibility_change` adhoc tasks to be performed.
  - That means it takes some times for moodle to perform the duplicate event and then when the workflow in opencast is finished the visibility change will take place (so wait until both are done)
- At the end you should confirm that the imported videos (duplicated) have the same original visibility status (except group) in the new course. (hidden->hidden) (visible->visible) (group->hidden)