### PR TITLE
increased the version number to create table for new version

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -829,7 +829,7 @@ function xmldb_block_opencast_upgrade($oldversion) {
         upgrade_block_savepoint(true, 2022111000, 'opencast');
     }
 
-    if ($oldversion < 2024030600) {
+    if ($oldversion < 2024061400) {
 
         // Define field id to be added to block_opencast_importmapping.
         $table = new xmldb_table('block_opencast_importmapping');
@@ -858,7 +858,7 @@ function xmldb_block_opencast_upgrade($oldversion) {
         }
 
         // Opencast savepoint reached.
-        upgrade_block_savepoint(true, 2024030600, 'opencast');
+        upgrade_block_savepoint(true, 2024061400, 'opencast');
     }
 
     return true;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_opencast';
 $plugin->release = 'v4.4-r1';
-$plugin->version = 2024060400;
+$plugin->version = 2024061400;
 $plugin->requires = 2022112800; // Requires Moodle 4.1+.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [


### PR DESCRIPTION
currently, it is not possible to upgrade from v4.3-r2 to v4.4-r1
The adjusted upgrade.php adds the table if it does not exist, therefore resolving the issue when releasing a new version while still being compatible with older versions.