### PR TITLE
Applying correct default completion while building LTI module

### DIFF
--- a/classes/local/ltimodulemanager.php
+++ b/classes/local/ltimodulemanager.php
@@ -443,7 +443,7 @@ class ltimodulemanager {
         $moduleinfo->availability = $availability;
 
         // Apply completion defaults.
-        $module = $DB->get_record('modules', ['name' => 'opencast']);
+        $module = $DB->get_record('modules', ['name' => 'lti'], '*', MUST_EXIST);
         $defaults = manager::get_default_completion($course, $module);
         if ($module) {
             foreach ($defaults as $key => $value) {


### PR DESCRIPTION
This PR fixes #377 

## Description
The problem occurs when admin decides to use LTI module in `block_opencast` only without installing Opencast Activity Plugin `mod_opencast`. When creating an LTI module via `block_opencast`, it ended up throwing error that complains about missing opencast activity module, which forces to have that plugin!

## Solution
This fix applies the correct/related module name "lti" and set the must exists flag, instead of "opencast" module or the `mod_opencast` plugin.
By adding `MUST_EXIST`, we make sure that lti module is a requirement to create lti module in opencast which is the right thing to do!

## Testing
- Patch this PR.
- Make sure to have LTI preconfigured external tool ready.
- Make sure to correctly configure the LTI modules in admin settings of the this plugin!
- Make sure to **not** to have the `mod_opencast` plugin installed.
- Have a course with the opencast block that has at least one video ready.
- Go to the video list and try to make the LTI module (LTI Provider) for the video.
- Result **with** this patch would be to: successfully creating LTI module provider.
- Result **without** this patch would be to see the error `invalid plugin_support mod_`