### PR TITLE
New "location" events' metadata field 

### DIFF
--- a/classes/local/addvideo_form.php
+++ b/classes/local/addvideo_form.php
@@ -169,6 +169,14 @@ class addvideo_form extends moodleform {
                 });
             }
 
+            // Converting value to default value if exists in params JSON.
+            $configureddefault = null;
+            if (isset($param['value'])) {
+                $configureddefault = $param['value'];
+                // We unset this here, to make it clean.
+                unset($param['value']);
+            }
+
             // Get the created element back from addElement function, in order to further use its attrs.
             $element = $mform->addElement($field->datatype, $field->name, $this->try_get_string($field->name, 'block_opencast'),
                 $param, $attributes);
@@ -194,7 +202,25 @@ class addvideo_form extends moodleform {
                 }
             }
             $mform->setAdvanced($field->name, !$field->required);
-            $default = (isset($eventdefaults[$field->name]) ? $eventdefaults[$field->name] : null);
+
+            $default = null;
+            if (!empty($configureddefault)) {
+                $default = $configureddefault;
+                // If the default value from the param JSON is used (configured default) and the field is read-only,
+                // this indicates that the field should be displayed in read-only mode and the default value must
+                // also be included in the metadata catalog.
+                if ($field->readonly) {
+                    // We now make sure that the read-only field send its value by form submit.
+                    $element->setPersistantFreeze(true);
+                }
+            }
+
+            // We give precedence to the event defaults configured in the course through "Manage default values".
+            if (isset($eventdefaults[$field->name])) {
+                $default = $eventdefaults[$field->name];
+            }
+
+            // In case we have default value.
             if ($default) {
                 $mform->setDefault($field->name, $default);
             }

--- a/classes/local/batchupload_form.php
+++ b/classes/local/batchupload_form.php
@@ -149,6 +149,14 @@ class batchupload_form extends moodleform {
                 });
             }
 
+            // Converting value to default value if exists in params JSON.
+            $configureddefault = null;
+            if (isset($param['value'])) {
+                $configureddefault = $param['value'];
+                // We unset this here, to make it clean.
+                unset($param['value']);
+            }
+
             // Get the created element back from addElement function, in order to further use its attrs.
             $element = $mform->addElement($field->datatype, $field->name, $this->try_get_string($field->name, 'block_opencast'),
                 $param, $attributes);
@@ -174,7 +182,25 @@ class batchupload_form extends moodleform {
                 }
             }
             $mform->setAdvanced($field->name, !$field->required);
-            $default = (isset($eventdefaults[$field->name]) ? $eventdefaults[$field->name] : null);
+
+            $default = null;
+            if (!empty($configureddefault)) {
+                $default = $configureddefault;
+                // If the default value from the param JSON is used (configured default) and the field is read-only,
+                // this indicates that the field should be displayed in read-only mode and the default value must
+                // also be included in the metadata catalog.
+                if ($field->readonly) {
+                    // We now make sure that the read-only field send its value by form submit.
+                    $element->setPersistantFreeze(true);
+                }
+            }
+
+            // We give precedence to the event defaults configured in the course through "Manage default values".
+            if (isset($eventdefaults[$field->name])) {
+                $default = $eventdefaults[$field->name];
+            }
+
+            // In case we have default value.
             if ($default) {
                 $mform->setDefault($field->name, $default);
             }

--- a/classes/setting_default_manager.php
+++ b/classes/setting_default_manager.php
@@ -78,7 +78,9 @@ class setting_default_manager {
             '{"name":"creator","datatype":"autocomplete","required":0,"readonly":0,"param_json":null,"defaultable":0,' .
             '"batchable":0},' .
             '{"name":"contributor","datatype":"autocomplete","required":0,"readonly":0,"param_json":null,"defaultable":0,' .
-            '"batchable":0}]';
+            '"batchable":0},' .
+            '{"name":"location","datatype":"text","required":0,"readonly":1,"param_json":"{\"value\":\"Moodle\"}"' .
+            ',"defaultable":0,"batchable":0}]';
     }
 
     /**

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -885,5 +885,50 @@ function xmldb_block_opencast_upgrade($oldversion) {
         upgrade_block_savepoint(true, 2024093000, 'opencast');
     }
 
+    // Taking care of new "location" metadata field for events.
+    if ($oldversion < 2024111103) {
+        // First, we read all the current "metadata" config settings if exist.
+
+        $params = ['plugin' => 'block_opencast', 'configname' => '%metadata\_%'];
+        $whereclause = $DB->sql_equal('plugin', ':plugin') . ' AND ' . $DB->sql_like('name', ':configname');
+        if ($entries = $DB->get_records_select('config_plugins', $whereclause, $params, '', 'name, value')) {
+            foreach ($entries as $entry) {
+                $eventmetadata = $entry->value;
+                // We only need to add the new location if the metadata config is not empty,
+                // if it is empty, it means it is not properly saved yet, so we do not need to do anything.
+                if (!empty($entry->value)) {
+                    // Decode the existing metadata JSON to an array.
+                    $metadata = json_decode($entry->value, true);
+                    // Check if the location metadata already exists.
+                    $locationmetadataexists = array_filter($metadata, function ($metadataentry) {
+                        return $metadataentry['name'] === 'location';
+                    });
+                    // If the location metadata already exists, we do not need to add it again.
+                    if (!empty($locationmetadataexists)) {
+                        continue;
+                    }
+                    // If the location metadata does not exist, we create a new entry for it.
+                    // Create a new entry for the location metadata.
+                    $locationmetadataarray = [
+                        "name" => "location",
+                        "datatype" => "text",
+                        "required" => 0,
+                        "readonly" => 1,
+                        "param_json" => "{\"value\":\"Moodle\"}", // Default value for the location metadata.
+                        "defaultable" => 0,
+                        "batchable" => 0,
+                    ];
+                    // Add the new location entry to the metadata array.
+                    $metadata[] = $locationmetadataarray;
+                    // Encode the metadata array back to JSON.
+                    $newmetadata = json_encode($metadata);
+                    // Save the new metadata back to the config with added location metadata.
+                    set_config($entry->name, $newmetadata, 'block_opencast');
+                }
+            }
+        }
+        upgrade_block_savepoint(true, 2024111103, 'opencast');
+    }
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_opencast';
 $plugin->release = 'v4.5-r3';
-$plugin->version = 2024111102;
+$plugin->version = 2024111103;
 $plugin->requires = 2024100700; // Requires Moodle 4.5+.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [


### PR DESCRIPTION
This PR fixes #114,

### Description
like what is presented by Studio as the location metadata field for the new events, we now want the exact same thing to be passed as metadata field "location" and to have "Moodle" value, to determine that the uploaded video is coming from Moodle!

### How it works:
- Add a new "location" event metadata field to the default metadata values that contains Moodle, and it is read-only!
- A new feature has been added to the upload forms which makes it possible for the configured metadata to have defined value as set in Parameters (JSON) column and be read-only, on the other hand the value of the read-only field in this case will be added to the form data when submitted, but not changable by the users!
   - So with this feature, if  admin wants to add a pre-defined read-only metadata to have custom value, it is simply done when the metadata field in admin setting config is set to read-only and have the json format value (e.g. {"value": "Moodle"}) as for the Parameters (JSON) column

![Screenshot 2025-01-06 at 13 02 41](https://github.com/user-attachments/assets/45951a89-18a5-4178-a74d-aeaf2fec0a11)

### Important to know:
- As to provide an upgrade step in order to add this new metadata field, the plugin version is now set to `2024111103` for testing purposes, therefore just pay attention to this new versioning.
- _It is important to also adjust the `$oldversion` and `upgrade_block_savepoint` in the `upgrade.php` file when this is merged and for the new release!_

### How to TEST
- Patch this PR
- Navigate to Admin settings of the plugin and locate Events' Metadata.
- Make sure that there is a new metadata filed called "location" which is read-only and have default value of Moodle!
- You can change "Moodle" with whatever you like.
- Make sure `showlocation`setting option  in Appearance section is enabled!
- Save changes
- Go to upload form/ batch upload form
- Expand the metadata fields (Show more...)
- Make sure you can locate the "Location" field which has the default value you already set in admin setting and it is read-only!
- Upload a video.
- After the video uploaded and processed, make sure you can see the value you have added as for location is presented in the table (Location column)
