### PR TITLE
Behat fixes: adding new parameters in mock api calls

### DIFF
--- a/tests/fixtures/api_calls/get/api_events_byseries_1.json
+++ b/tests/fixtures/api_calls/get/api_events_byseries_1.json
@@ -1,5 +1,5 @@
 {
-  "resource": "/api/events?filter=is_part_of:1234-1234-1234-1234-1234&sort=start_date:DESC&sign=true&withacl=true&withmetadata=true&withpublications=true&limit=6",
+  "resource": "/api/events?filter=is_part_of:1234-1234-1234-1234-1234&sort=start_date:DESC&sign=true&withacl=true&withmetadata=true&withpublications=true&includeInternalPublication=false&limit=6",
   "status": 200,
   "body": [
     {

--- a/tests/fixtures/api_calls/get/api_events_byseries_2.json
+++ b/tests/fixtures/api_calls/get/api_events_byseries_2.json
@@ -1,5 +1,5 @@
 {
-  "resource": "/api/events?filter=is_part_of:1111-1111-1111-1111-1111&sort=start_date:DESC&sign=true&withacl=true&withmetadata=true&withpublications=true&limit=6",
+  "resource": "/api/events?filter=is_part_of:1111-1111-1111-1111-1111&sort=start_date:DESC&sign=true&withacl=true&withmetadata=true&withpublications=true&includeInternalPublication=false&limit=6",
   "status": 200,
   "body": [
     {

--- a/tests/fixtures/api_calls/get/init_api_workflow_definitions_duplicate_event.json
+++ b/tests/fixtures/api_calls/get/init_api_workflow_definitions_duplicate_event.json
@@ -1,5 +1,5 @@
 {
-  "resource": "/api/workflow-definitions/duplicate-event?withoperations=false&withconfigurationpanel=true",
+  "resource": "/api/workflow-definitions/duplicate-event?withoperations=false&withconfigurationpanel=true&withconfigurationpaneljson=false",
   "status": 200,
   "body": {
     "identifier": "duplicate-event",


### PR DESCRIPTION
This PR fixes #420

It contains new parameters to the mock api calls, which have been introduced in new oc-php-lib in tool plugin.