### PR TITLE
Improve video table sorting

### DIFF
--- a/.github/workflows/moodle-release.yml
+++ b/.github/workflows/moodle-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   call-moodle-release-workflow:
-    uses: Opencast-Moodle/moodle-workflows-opencast/.github/workflows/moodle-release.yml@master
+    uses: Opencast-Moodle/moodle-workflows-opencast/.github/workflows/moodle-release.yml@main
     with:
       plugin-name: 'block_opencast'
     secrets: inherit

--- a/index.php
+++ b/index.php
@@ -231,7 +231,10 @@ $perpage = optional_param('perpage', 20, PARAM_INT);
 $opencast = apibridge::get_instance($ocinstanceid);
 $table = $renderer->create_videos_tables('ignore', $headers, $columns, $baseurl);
 $sortcolumns = $table->get_sort_columns();
-
+// If we don't have a sortcolumn we sort by date desc
+if(empty($sortcolumns)){
+    $sortcolumns = ['start_date' => 3];
+}
 
 echo $OUTPUT->header();
 

--- a/renderer.php
+++ b/renderer.php
@@ -263,7 +263,9 @@ class block_opencast_renderer extends plugin_renderer_base {
         $table->no_sorting('published');
         $table->no_sorting('visibility'); // This column cannot be sortable because it does not mean anything to Opencast!
         $table->no_sorting('select');
-        $table->sortable(true, 'start_date', SORT_DESC);
+        $table->text_sorting('title');
+        $table->sortable(true, null, SORT_DESC);
+        $table->maxsortkeys=1;
 
         $table->column_style('selectall', 'max-width', '40px');
         $table->column_style('start_date', 'min-width', '125px');


### PR DESCRIPTION
This PR adjusts the sorting of the videos table in the block overview page.
The current behaviour is, that the videos table is always sorted by the start_date, if a second column is picked in the UI the videos table gets multi sorted by the start_date and the picked column.
This PR changes the behaviour to fully sort the table by the newly picked column instead of multisorting.

If there won't be another Moodle 4.5 Release, I can rebase this PR for Moodle 5.0.
