### PR TITLE
Fix for block deletion error on non-view pages

### DIFF
--- a/block_opencast.php
+++ b/block_opencast.php
@@ -234,7 +234,7 @@ class block_opencast extends block_base {
                     $deleteaction->attributes['class'] .= ' block_opencast_delete';
                 }
                 $bc->controls[$index] = $deleteaction;
-                $deleteurl = new moodle_url('/course/view.php', [
+                $deleteurl = new moodle_url($this->page->url, [
                         'id' => $COURSE->id,
                         'bui_deleteid' => $this->instance->id,
                         'bui_confirm' => 1,


### PR DESCRIPTION
The block deletion URL in block_opencast.php was hardcoded to /course/view.php which caused an error when trying to delete the block on non-view pages (e.g. course settings)

Fix: Replace the hardcoded path with $this->page->url so it dynamically resolves to the current page URL